### PR TITLE
chore: enable SonarCloud code quality analysis

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,22 @@
+name: SonarCloud Analysis
+permissions:
+  contents: read
+  pull-requests: read
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - name: SonarCloud Scan
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=petry-projects_ContentTwin
+sonar.organization=petry-projects
+sonar.projectName=ContentTwin
+sonar.sources=.
+sonar.exclusions=_bmad-output/**,.claude/**


### PR DESCRIPTION
## Summary
- Add SonarCloud configuration and GitHub Actions workflow
- Runs code quality analysis on pushes to main and PRs
- SonarCloud is free for open source projects
- Uses pinned commit SHAs and least-privilege permissions
- SONAR_TOKEN gated at job-level env for correct fork PR handling

## Setup required
- [ ] Create SonarCloud project at sonarcloud.io for petry-projects/ContentTwin
- [ ] Add `SONAR_TOKEN` secret to the repository settings

## Test plan
- [ ] Verify workflow triggers on next PR
- [ ] Confirm SonarCloud analysis results appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)