### PR TITLE
chore: refine CodeRabbit config to exclude non-code directories

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,6 +7,10 @@ reviews:
     drafts: false
     base_branches:
       - main
+  path_filters:
+    - "!_bmad/**"
+    - "!_bmad-output/**"
+    - "!.claude/**"
   path_instructions:
     - path: "**/*.py"
       instructions: >


### PR DESCRIPTION
## Summary
- Add `path_filters` to exclude `_bmad/**`, `_bmad-output/**`, and `.claude/**` from reviews
- These are BMAD method templates, generated planning artifacts, and Claude Code config — not project code
- Reduces review noise and focuses CodeRabbit on actual source code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)