### PR TITLE
chore: refine SonarCloud exclusions for non-code directories

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,4 @@ sonar.projectKey=petry-projects_ContentTwin
 sonar.organization=petry-projects
 sonar.projectName=ContentTwin
 sonar.sources=.
-sonar.exclusions=_bmad-output/**,.claude/**
+sonar.exclusions=_bmad/**,_bmad-output/**,.claude/**


### PR DESCRIPTION
## Summary
- Add `_bmad/**` to `sonar.exclusions` (BMAD method templates, not project code)
- Ensures `_bmad/**`, `_bmad-output/**`, and `.claude/**` are all excluded
- Reduces scan noise and focuses analysis on actual source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)