### PR TITLE
ci: switch auto-merge to --auto and resolve AI reviewer threads

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,67 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v2
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Generate app token
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.dependency-type == 'indirect'
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Approve, resolve threads, and auto-merge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.dependency-type == 'indirect'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Approve the PR
+          gh pr review --approve "$PR_URL"
+
+          # Resolve all review threads (from Copilot, CodeRabbit, etc.)
+          THREADS=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  reviewThreads(first: 100) {
+                    nodes { id isResolved }
+                  }
+                }
+              }
+            }' -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" \
+            --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .id')
+
+          for THREAD_ID in $THREADS; do
+            gh api graphql -f query='
+              mutation($id: ID!) {
+                resolveReviewThread(input: {threadId: $id}) {
+                  thread { isResolved }
+                }
+              }' -f id="$THREAD_ID" --silent
+          done
+
+          # Queue auto-merge (waits for all checks to pass)
+          gh pr merge --squash --auto "$PR_URL"


### PR DESCRIPTION
## Summary
- Replaces `gh pr merge --admin` with `gh pr merge --auto` to fix the race condition where the merge fires before CI checks complete
- Adds a step to resolve all review threads (from Copilot, CodeRabbit, etc.) before queuing auto-merge
- Required because the new `pr-quality` ruleset enforces `required_review_thread_resolution`

## Test plan
- [ ] Verify next Dependabot patch/minor PR gets auto-merged after checks pass
- [ ] Verify review threads from AI reviewers are resolved before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)