### PR TITLE
chore: enable Claude issue trigger per org CI standard

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,5 @@
 name: Claude Code
 
-permissions: {}
-
 on:
   pull_request:
     branches: [main]
@@ -10,6 +8,10 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  issues:
+    types: [labeled]
+
+permissions: {}
 
 jobs:
   claude:
@@ -21,16 +23,21 @@ jobs:
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'issues' && github.event.action == 'labeled' &&
+        github.event.label.name == 'claude')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      contents: read
+      # write required for issue-triggered branch creation
+      contents: write
       id-token: write
       pull-requests: write
       issues: write
     steps:
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@e7b588b6eaa5263c2e7c6c7b34a29e190d32ee68 # v1
+        if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
+        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          label_trigger: "claude"


### PR DESCRIPTION
## Summary

- Adds `issues: [labeled]` event trigger to `claude.yml` so applying the `claude` label to any issue triggers Claude to work it autonomously
- Upgrades `contents` permission from `read` to `write` (required for issue-triggered branch creation)
- Pins `claude-code-action` to `v1.0.89` (`6e2bd528`) matching the org standard
- Adds `label_trigger: "claude"` input to the action
- Adds dependabot skip condition
- Created the `claude` label (`#7c3aed`) on this repository

Implements the standard defined in [petry-projects/.github#24](https://github.com/petry-projects/.github/pull/24).

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merge, apply `claude` label to a test issue and confirm Claude picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)