### PR TITLE
ci: add CI pipeline workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
             -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
 
       - name: Check shell script formatting
-        run: shfmt -d scripts/*.sh
+        run: shfmt -i 2 -d scripts/*.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+# CI Pipeline
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#1-ci-pipeline-ciyml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Lint shell scripts
+        run: shellcheck scripts/*.sh
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install shfmt
+        run: |
+          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.10.0/shfmt_v3.10.0_linux_amd64 \
+            -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+
+      - name: Check shell script formatting
+        run: shfmt -d scripts/*.sh


### PR DESCRIPTION
## Summary

- Adds the required `ci.yml` workflow to resolve the `missing-ci.yml` compliance finding (issue #20)
- Pipeline lints shell scripts with `shellcheck` and format-checks with `shfmt`
- Follows ci-standards.md patterns: `permissions: {}` at workflow level, scoped grants per-job, `concurrency` with `cancel-in-progress: true`
- `actions/checkout` is SHA-pinned per the Action Pinning Policy

## Tech stack note

The repo currently contains shell scripts only (`scripts/*.sh`). When TypeScript/Node.js code is added, the CI should be extended following the npm pattern documented in ci-standards.md.

Closes #20

Generated with [Claude Code](https://claude.ai/code)