### PR TITLE
fix: pin claude.yml reusable workflow to SHA

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/claude-code-reusable.yml` from `@v1` to commit SHA `ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1`
- Resolves the compliance finding from the weekly audit

## Motivation

The [Action Pinning Policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy) requires all GitHub Actions to be pinned to a specific commit SHA rather than a mutable tag. The SHA was resolved via `gh api repos/petry-projects/.github/git/refs/tags/v1` (annotated tag → commit SHA dereference).

Closes #57

Generated with [Claude Code](https://claude.ai/code)