### PR TITLE
fix: pin dependabot-rebase-reusable workflow to SHA (action pinning compliance)

### DIFF
--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -39,5 +39,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1
     secrets: inherit


### PR DESCRIPTION
## Summary

Pins `petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml` from `@v1` to the corresponding commit SHA to comply with the [action pinning policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy).

**Change:**
```
- uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@v1
+ uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1
```

The SHA `ae9709f4466dec60a5733c9e7487f69dcd004e05` was resolved from the `v1` annotated tag via `gh api`.

Closes #59

Generated with [Claude Code](https://claude.ai/code)