### PR TITLE
fix: pin dependabot-automerge reusable workflow to SHA

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml` from `@v1` to commit SHA `ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1`
- Satisfies the [action-pinning policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy)

Closes #58

Generated with [Claude Code](https://claude.ai/code)