### PR TITLE
fix(ci): pin claude-code-reusable.yml to SHA and sync check_run trigger

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,12 +31,14 @@ on:
     types: [created]
   issues:
     types: [labeled]
+  check_run:
+    types: [completed]
 
 permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Pin `petry-projects/.github/.github/workflows/claude-code-reusable.yml` from `@v1` to `@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1` (SHA resolved by dereferencing the `v1` tag via GitHub API)
- Sync the missing `check_run: types: [completed]` trigger from the current standards template (`petry-projects/.github/standards/workflows/claude.yml`)

Both changes bring `claude.yml` into full conformance with the standards template.

Closes #57

Generated with [Claude Code](https://claude.ai/code)