### PR TITLE
fix: remove duplicate .github/ segment in reusable workflow paths

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/agent-shield.yml
 # Standard:        petry-projects/.github/standards/agent-standards.md
-# Reusable:        petry-projects/.github/.github/workflows/agent-shield-reusable.yml
+# Reusable:        petry-projects/.github/workflows/agent-shield-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. The AgentShield CLI scan and the
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/workflows/agent-shield-reusable.yml@v1

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-automerge.yml
 # Standard:        petry-projects/.github/standards/dependabot-policy.md
-# Reusable:        petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml
+# Reusable:        petry-projects/.github/workflows/dependabot-automerge-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All eligibility logic and the GitHub
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    uses: petry-projects/.github/workflows/dependabot-automerge-reusable.yml@v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Removes the duplicate `.github/` segment from `uses:` paths in two workflow files
- Fixes `petry-projects/.github/.github/workflows/` → `petry-projects/.github/workflows/` in both `agent-shield.yml` and `dependabot-automerge.yml`
- Resolves the `reusable-workflow-path-duplicate-github` compliance finding

## Changes

| File | Before | After |
|------|--------|-------|
| `.github/workflows/agent-shield.yml` | `petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1` | `petry-projects/.github/workflows/agent-shield-reusable.yml@v1` |
| `.github/workflows/dependabot-automerge.yml` | `petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1` | `petry-projects/.github/workflows/dependabot-automerge-reusable.yml@v1` |

> **Note:** The org-level standard templates (`petry-projects/.github/standards/workflows/`) also contain the duplicate path. A separate fix may be needed upstream to update those templates.

Closes #110

Generated with [Claude Code](https://claude.ai/code)