### PR TITLE
fix(workflows): sync claude.yml and dependabot-rebase.yml with org standard templates

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,6 +31,8 @@ on:
     types: [created]
   issues:
     types: [labeled]
+  check_run:
+    types: [completed]
 
 permissions: {}
 

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -6,12 +6,13 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All rebase/merge serialization logic
 #     lives in the reusable workflow above.
-#   • You MAY change: nothing in this file in normal use. Adopt verbatim.
+#   • You MAY change: the SHA in the `uses:` line when upgrading the reusable
+#     workflow version (bump SHA to latest main of petry-projects/.github).
 #   • You MUST NOT change: trigger event, the concurrency group name,
-#     the `uses:` line, `secrets: inherit`, or the job-level `permissions:`
-#     block — reusable workflows can be granted no more permissions than the
-#     calling job has, so removing the stanza breaks the reusable's gh API
-#     calls.
+#     the explicit secrets block, or the job-level `permissions:` block —
+#     reusable workflows can be granted no more permissions than the calling
+#     job has, so removing the stanza breaks
+#     the reusable's gh API calls.
 #   • If you need different behaviour, open a PR against the reusable in the
 #     central repo.
 # ─────────────────────────────────────────────────────────────────────────────
@@ -27,6 +28,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # allow manual trigger to flush Dependabot PR queue
 
 concurrency:
   group: dependabot-update-and-merge
@@ -37,7 +39,9 @@ permissions: {}
 jobs:
   dependabot-rebase:
     permissions:
-      contents: read
-      pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@v1
-    secrets: inherit
+      contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
+      pull-requests: write  # re-approve PRs after branch update
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@3c6335c6ee3e2f1a37f3e27e065e28d36d9c0dde # v1
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- **`claude.yml`**: adds the missing `check_run: types: [completed]` trigger to match the org standard template
- **`dependabot-rebase.yml`**: adds `workflow_dispatch` trigger, upgrades permissions to `write` for `contents` and `pull-requests`, SHA-pins the reusable workflow reference (`@3c6335c6...`), and switches from `secrets: inherit` to explicit `APP_ID` / `APP_PRIVATE_KEY` secrets
- **`dependency-audit.yml`**: already identical to template — no change required

## Note on the compliance finding

The compliance check (`reusable-workflow-path-duplicate-github`) flags `petry-projects/.github/.github/workflows/` as having a duplicate `.github/` segment.  However, this is actually the **correct** GitHub Actions syntax when the referenced repo is literally named `.github`:

```
{owner}/{repo}/.github/workflows/{file}@{ref}
          ↑         ↑
      repo name  required path prefix
```

The org standard templates in `petry-projects/.github/standards/workflows/` themselves use this same `petry-projects/.github/.github/workflows/` pattern, so changing it to `petry-projects/.github/workflows/` would produce invalid workflow references and break CI.

The compliance check should be updated to exclude the `petry-projects/.github` special case, or the check's regex should be aware that `{repo}/.github/` is valid when the repo name is `.github`.

## Test plan

- [ ] CI passes on this PR
- [ ] `dependabot-rebase` workflow triggers on next push to main
- [ ] `claude` workflow triggers on `check_run` completed events

Closes #111

Generated with [Claude Code](https://claude.ai/code)