### PR TITLE
fix: correct reusable workflow path (remove duplicate .github/)

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/agent-shield.yml
 # Standard:        petry-projects/.github/standards/agent-standards.md
-# Reusable:        petry-projects/.github/.github/workflows/agent-shield-reusable.yml
+# Reusable:        petry-projects/.github/workflows/agent-shield-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. The AgentShield CLI scan and the
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/workflows/agent-shield-reusable.yml@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/claude.yml
 # Standard:        petry-projects/.github/standards/ci-standards.md#4-claude-code-claudeyml
-# Reusable:        petry-projects/.github/.github/workflows/claude-code-reusable.yml
+# Reusable:        petry-projects/.github/workflows/claude-code-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All Claude Code logic, the prompt,
@@ -36,7 +36,7 @@ permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/workflows/claude-code-reusable.yml@v1
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-automerge.yml
 # Standard:        petry-projects/.github/standards/dependabot-policy.md
-# Reusable:        petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml
+# Reusable:        petry-projects/.github/workflows/dependabot-automerge-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All eligibility logic and the GitHub
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    uses: petry-projects/.github/workflows/dependabot-automerge-reusable.yml@v1
     secrets: inherit

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-rebase.yml
 # Standard:        petry-projects/.github/standards/dependabot-policy.md
-# Reusable:        petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml
+# Reusable:        petry-projects/.github/workflows/dependabot-rebase-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All rebase/merge serialization logic
@@ -39,5 +39,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@v1
+    uses: petry-projects/.github/workflows/dependabot-rebase-reusable.yml@v1
     secrets: inherit

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependency-audit.yml
 # Standard:        petry-projects/.github/standards/ci-standards.md#5-dependency-audit-dependency-auditym
-# Reusable:        petry-projects/.github/.github/workflows/dependency-audit-reusable.yml
+# Reusable:        petry-projects/.github/workflows/dependency-audit-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All ecosystem-detection and audit logic
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1
+    uses: petry-projects/.github/workflows/dependency-audit-reusable.yml@v1


### PR DESCRIPTION
Fixes reusable workflow reference syntax.

Changed from: `petry-projects/.github/.github/workflows/...`
Changed to: `petry-projects/.github/workflows/...`

Related: https://github.com/petry-projects/.github/pull/154