### PR TITLE
fix: replace SHA-pinned auto-rebase ref with canonical @v1 stub

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -38,5 +38,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@126c1441ee9cf040f2ce3ef0eda85d459b82f8e9 # v1
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Replaces the SHA-pinned `@126c1441ee9cf040f2ce3ef0eda85d459b82f8e9 # v1` reference in `.github/workflows/auto-rebase.yml` with the canonical `@v1` tag reference per org standard
- File copied verbatim from `petry-projects/.github/standards/workflows/auto-rebase.yml`
- Adds trailing newline (minor formatting fix)

## Compliance

Resolves the `non-stub-auto-rebase.yml` compliance finding — the workflow now uses the canonical stub delegating to `petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v1` as required by [ci-standards.md#centralization-tiers](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#centralization-tiers).

Closes #118

Generated with [Claude Code](https://claude.ai/code)