### PR TITLE
chore: standardize CODEOWNERS on @petry-projects/org-leads

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
-# Code owners for ContentTwin
-# These owners will be automatically requested for review on pull requests.
+# CODEOWNERS
+# Standard: use the @petry-projects/org-leads team for all code owner
+# assignments. See petry-projects/.github standards/codeowners-standard.md
 
-* @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry
+* @petry-projects/org-leads


### PR DESCRIPTION
Per the [org CODEOWNERS standard](https://github.com/petry-projects/.github/blob/main/standards/codeowners-standard.md), replace individual user/bot listings with the @petry-projects/org-leads team. Closes CODEOWNERS gap from pr-review-agent#27.