### PR TITLE
fix: clarify CODEOWNERS comment to match org standard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
-# CODEOWNERS
-# Standard: use the @petry-projects/org-leads team for all code owner
-# assignments. See petry-projects/.github standards/codeowners-standard.md
+# CODEOWNERS — petry-projects standard (codeowners-standard.md)
+#
+# Rule: @petry-projects/org-leads MUST be the FIRST owner on every line.
+# Additional teams may follow. Individual users are forbidden.
 
 * @petry-projects/org-leads


### PR DESCRIPTION
## Summary

- The `.github/CODEOWNERS` file already contained the compliant owner line (`* @petry-projects/org-leads`) added in #127
- Issue #130 was a **false positive** from the compliance audit: the script received 404 API responses for all three candidate paths (`CODEOWNERS`, `.github/CODEOWNERS`, `docs/CODEOWNERS`) and treated the concatenated JSON error bodies as file content, incorrectly triggering the `codeowners-org-leads-not-first` check
- This PR improves the comment block in CODEOWNERS to explicitly document all three rules from `codeowners-standard.md`, making future audits and human reviewers less likely to question the file's intent

## Changes

- Updated the comment header in `.github/CODEOWNERS` to explicitly document:
  1. `@petry-projects/org-leads` must be the FIRST owner on every line
  2. Additional teams may follow
  3. Individual users are forbidden

The owner rule itself (`* @petry-projects/org-leads`) is unchanged and was already compliant.

Closes #130

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership configuration file to align with standardized conventions and requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/ContentTwin/pull/135)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->