### PR TITLE
fix: pin pr-review-mention reusable workflow to SHA

### DIFF
--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -34,5 +34,5 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@0cb4bba11d7563bf197ad805f12fb8639e4879e4 # v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml` from `@v1` to commit SHA `0cb4bba11d7563bf197ad805f12fb8639e4879e4` (v1) in `.github/workflows/pr-review-mention.yml`
- Resolves the `unpinned-actions` compliance finding raised by the weekly audit

## Changes

```diff
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@0cb4bba11d7563bf197ad805f12fb8639e4879e4 # v1
```

The SHA was resolved via:
```
gh api repos/petry-projects/.github/git/refs/tags/v1 --jq '.object.sha'
# → 0cb4bba11d7563bf197ad805f12fb8639e4879e4 (type: commit)
```

Closes #140

Generated with [Claude Code](https://claude.ai/code)