### PR TITLE
feat(copilot): add repo-level Copilot instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,4 +55,8 @@ All scripts must follow shell safety standards: `#!/usr/bin/env bash` with `set 
 
 ## Org Standards
 
-See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md).
+See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md) for org-wide development standards.
+
+**Language-specific instructions** (applied automatically by Copilot when you open matching file types):
+
+- [Shell](.github/instructions/shell.instructions.md) — safety flags, ShellCheck, quoting, error handling, Makefile standards

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 ## About
 
-ContentTwin is a repository security and analysis settings automation tool — a collection of shell scripts that apply required GitHub repository configurations (secret scanning, push protection, code scanning, rulesets) across the petry-projects org.
+ContentTwin is a repository security and analysis settings automation tool — a collection of shell scripts that apply required GitHub repository configurations (secret scanning, push protection, rulesets) across the petry-projects org.
 
 ## Tech Stack
 
@@ -27,7 +27,6 @@ scripts/
     apply-secret-scanning-ai-detection.sh
   workflows/
     ci.yml                        # Runs ShellCheck + shfmt on every PR
-    codeql.yml                    # CodeQL SAST scan
     ...
 ```
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,58 @@
+# Copilot Instructions — ContentTwin
+
+> **Note:** This file applies to the `petry-projects/ContentTwin` repository only. Org-wide rules are in [`petry-projects/.github/copilot-instructions.md`](https://github.com/petry-projects/.github/blob/main/.github/copilot-instructions.md). This file covers only what is specific to ContentTwin.
+
+## About
+
+ContentTwin is a repository security and analysis settings automation tool — a collection of shell scripts that apply required GitHub repository configurations (secret scanning, push protection, code scanning, rulesets) across the petry-projects org.
+
+## Tech Stack
+
+- **Runtime:** Bash
+- **Framework:** GitHub CLI (`gh`) for GitHub API operations
+- **Testing:** ShellCheck (linting) · `shfmt` (formatting) — both enforced as CI gates
+- **Linting:** ShellCheck (zero warnings required)
+- **Key tools:** `gh` CLI (required, with repo admin scope)
+
+## Project Structure
+
+```text
+scripts/
+  apply-repo-settings.sh          # Applies security_and_analysis settings via GitHub API
+  setup-rulesets.sh               # Configures branch protection rulesets
+.github/
+  scripts/                        # GitHub Actions helper scripts
+    apply-code-quality-ruleset.sh
+    apply-repo-settings.sh
+    apply-secret-scanning-ai-detection.sh
+  workflows/
+    ci.yml                        # Runs ShellCheck + shfmt on every PR
+    codeql.yml                    # CodeQL SAST scan
+    ...
+```
+
+## Local Dev Commands
+
+- Lint:    `shellcheck scripts/*.sh`
+- Format:  `shfmt -l -w scripts/`
+- Run:     `bash scripts/apply-repo-settings.sh` (requires `gh` auth with repo admin scope)
+
+## Required Environment Variables
+
+- `GITHUB_TOKEN`: GitHub PAT with `repo` administration scope (or `gh auth login` interactively)
+- `GITHUB_REPOSITORY`: Target repo in `owner/repo` format (defaults to `petry-projects/ContentTwin`)
+
+## Testing Framework
+
+- Runner: ShellCheck — static analysis enforced as a required CI check
+- Format: `shfmt` — format check enforced as a required CI check
+- Coverage: N/A — scripts are validated by running against the target repository
+- Mutation testing: not configured
+
+## Repo-Specific Overrides
+
+All scripts must follow shell safety standards: `#!/usr/bin/env bash` with `set -euo pipefail`. No hardcoded tokens — use `$GITHUB_TOKEN` from the environment. Both ShellCheck and `shfmt` must pass before merge.
+
+## Org Standards
+
+See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md).

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,0 +1,139 @@
+---
+description: Shell script development standards for the Petry Projects organization
+applyTo: "**/*.sh,**/*.bash"
+---
+
+# Shell Script Development Standards
+
+These rules extend the org-level `copilot-instructions.md`. Shell scripts are used for CI
+helper utilities, compliance automation, and infrastructure orchestration.
+
+## Safety Flags
+
+Every shell script MUST begin with:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+```
+
+- `set -e` — exit immediately on any command failure
+- `set -u` — treat unset variables as errors
+- `set -o pipefail` — propagate failures through pipelines (not just the last command)
+
+For scripts that intentionally handle errors inline (e.g., checking return codes manually),
+disable `set -e` locally within a subshell or use `|| true` with a comment explaining why.
+
+## ShellCheck Compliance
+
+All scripts MUST pass `shellcheck` with zero warnings:
+
+```bash
+shellcheck --shell=bash <script>.sh
+```
+
+Run ShellCheck before committing. Common issues to fix proactively:
+
+- Unquoted variables — always quote: `"$variable"`, `"${array[@]}"`
+- Unsafe `$()` with user-controlled input — validate input first
+- Deprecated constructs — use `[[ ... ]]` over `[ ... ]` for bash conditionals
+
+## Quoting and Variable Expansion
+
+- **Always quote variable expansions:** `"$var"`, `"${var}"`, `"${array[@]}"`.
+- Use `${var:-default}` for safe defaults. Use `${var:?error message}` to fail fast on required
+  variables.
+- Use `$( )` for command substitution, not backticks.
+- Use `[[ ... ]]` for conditionals (bash built-in, safer than `[ ]`).
+- Use `(( ... ))` for arithmetic expressions.
+
+## Function Organization
+
+- Extract reusable logic into functions. Name functions with `snake_case`.
+- Declare local variables with `local` inside functions to avoid polluting global scope.
+- Functions that produce output should write to stdout. Functions that report errors should write
+  to stderr: `echo "Error: message" >&2`.
+
+  ```bash
+  log_info()  { echo "[INFO]  $*"; }
+  log_error() { echo "[ERROR] $*" >&2; }
+
+  process_item() {
+    local item="$1"
+    local output_dir="$2"
+    # ...
+  }
+  ```
+
+## Error Handling
+
+- Check return codes for commands that can fail silently (e.g., `curl`, `jq`, `aws`).
+- Use `|| { log_error "..."; exit 1; }` patterns to provide descriptive failure messages.
+- Use `trap 'cleanup' EXIT` to ensure cleanup runs even on error:
+
+  ```bash
+  cleanup() {
+    rm -f "$tmp_file"
+  }
+  trap 'cleanup' EXIT
+  ```
+
+## Command Injection Prevention
+
+- Never pass user-controlled input directly to shell commands without validation.
+- Use arrays to pass arguments to commands (avoids word-splitting and globbing):
+
+  ```bash
+  # Wrong — subject to word splitting:
+  run_command "$user_args"
+
+  # Right — use an array:
+  args=("--flag" "$user_value")
+  run_command "${args[@]}"
+  ```
+
+- Avoid `eval` with untrusted input.
+
+## Style and Readability
+
+- Use heredocs for multi-line strings instead of multiple `echo` statements:
+
+  ```bash
+  cat <<'EOF'
+  Usage: script.sh [options]
+    -h, --help    Show this help message
+  EOF
+  ```
+
+- Keep lines under 100 characters where practical. Use `\` to break long commands.
+- Add a one-line comment before each function and non-obvious command explaining *why*, not
+  *what*.
+- Use `readonly` for constants at the top of the script:
+
+  ```bash
+  readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  readonly MAX_RETRIES=3
+  ```
+
+## Makefile Standards
+
+- Use `.PHONY` for all non-file targets to prevent conflicts with files of the same name.
+- Use `$(MAKE)` recursively, not bare `make`.
+- Document each target with a `##` comment on the same line (enables `make help` patterns):
+
+  ```makefile
+  .PHONY: test lint
+
+  test: ## Run the full test suite with coverage
+  	go test ./... -coverprofile=coverage.out
+
+  lint: ## Run golangci-lint
+  	golangci-lint run
+  ```
+
+## Testing Shell Scripts
+
+- Test scripts with `bats` (Bash Automated Testing System) where feasible.
+- At minimum, test the happy path and common error paths.
+- Use `shellcheck` in CI as a required status check for repositories with significant shell
+  script surface area.

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: Shell script development standards for the Petry Projects organization
-applyTo: "**/*.sh,**/*.bash"
+applyTo: "**/*.sh,**/*.bash,**/Makefile,**/*.mk"
 ---
 
 # Shell Script Development Standards
@@ -85,7 +85,7 @@ Run ShellCheck before committing. Common issues to fix proactively:
 
   ```bash
   # Wrong — subject to word splitting:
-  run_command "$user_args"
+  run_command $user_args
 
   # Right — use an array:
   args=("--flag" "$user_value")

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .dev-lead/
 .dev-lead/
 .dev-lead/
+.dev-lead/


### PR DESCRIPTION
## Summary

- Adds `.github/copilot-instructions.md` customized for ContentTwin's Bash shell script stack
- Copies `shell.instructions.md` from the org canonical source
- Covers: ShellCheck + shfmt CI enforcement, `gh` CLI usage, safety flag requirements (`set -euo pipefail`), no-hardcoded-secrets rule

## Stack discovered

Bash · GitHub CLI (`gh`) · ShellCheck · `shfmt` · GitHub Actions (CI + CodeQL)

## References

- Org-wide rollout: petry-projects/.github PR #328
- Org baseline: [petry-projects/.github copilot-instructions.md](https://github.com/petry-projects/.github/blob/main/.github/copilot-instructions.md)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository-specific Copilot instructions outlining project purpose, structure, local development commands, environment variables, CI expectations, and shell safety practices.
  * Added organization-wide shell scripting standards covering shebangs and strict mode, linting and formatting, quoting/expansion rules, function conventions, error handling and cleanup patterns, command-injection prevention, style/readability guidance, Makefile conventions, and testing/CI requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->