### PR TITLE
fix: correct pr-auto-review reusable workflow reference

### DIFF
--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -1,0 +1,55 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/pr-auto-review.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All readiness-gate logic lives in the
+#     reusable workflow above.
+#   • You MAY change: the tag in the `uses:` line when upgrading the reusable
+#     workflow version (e.g. bump `@v2` → `@v3` when petry-projects/.github cuts
+#     a new release), and the workflow name(s) in `workflow_run.workflows` to
+#     match your repository's CI workflow name(s).
+#   • You MUST NOT change: trigger event types or the job-level `permissions:`
+#     block — reusable workflows can be granted no more permissions than the
+#     calling job, so removing the stanza breaks the reusable's gh API calls.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo.
+#   • When publishing a new version of this reusable, also update this template
+#     and open a fanout PR across all caller repos.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# PR Auto-Review — thin caller for the org-level reusable.
+# To adopt: copy this file to .github/workflows/pr-auto-review.yml in your repo.
+# Requires: GH_PAT_WORKFLOWS org secret (already present in petry-projects org).
+name: PR Auto-Review — Ready Check
+
+on:
+  # workflow_run fires when a named GitHub Actions workflow completes.
+  # check_suite does NOT trigger for GitHub Actions runs, so this is required
+  # to catch CI turning green on a PR.
+  # TODO: replace "CI" with your repository's CI workflow name(s).
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  # check_suite covers third-party CI checks (e.g. SonarCloud, external apps).
+  check_suite:
+    types: [completed]
+  # Re-evaluate readiness after review state changes.
+  pull_request_review:
+    types: [submitted, dismissed]
+  # Re-evaluate when the PR is first opened, updated, or comes out of draft.
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions: {}
+
+jobs:
+  pr-auto-review:
+    permissions:
+      pull-requests: read
+      checks: read
+      actions: read
+    uses: petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml@v2
+    secrets:
+      GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -28,9 +28,8 @@ on:
   # workflow_run fires when a named GitHub Actions workflow completes.
   # check_suite does NOT trigger for GitHub Actions runs, so this is required
   # to catch CI turning green on a PR.
-  # TODO: replace "CI" with your repository's CI workflow name(s).
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI", "AgentShield", "Dependency audit", "SonarCloud Analysis"]
     types: [completed]
   # check_suite covers third-party CI checks (e.g. SonarCloud, external apps).
   check_suite:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .dev-lead/
 .dev-lead/
 .dev-lead/
+.dev-lead/


### PR DESCRIPTION
Update pr-auto-review.yml to use @v2 tag for the reusable workflow.