### PR TITLE
fix(dev-lead): grant statuses:read + centralise concurrency

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -37,15 +37,9 @@ on:
 
 permissions: {}
 
-concurrency:
-  # One active run per repo; ci-relay (check_run) keeps an ephemeral per-SHA slot
-  # so it can fire immediately without blocking or being blocked by the dispatch queue.
-  group: >-
-    ${{
-      github.event_name == 'check_run' && format('dev-lead-ci-relay-{0}', github.event.check_run.head_sha) ||
-      'dev-lead'
-    }}
-  cancel-in-progress: false
+# Concurrency is centralised in the reusable workflow (dev-lead-reusable.yml) with
+# per-issue / per-PR lanes, so issue pickups are never cancelled by PR follow-up
+# traffic and the grouping can't drift per-repo. See petry-projects/.github#402.
 
 jobs:
   dev-lead:
@@ -57,3 +51,4 @@ jobs:
       issues: write
       actions: read
       checks: read
+      statuses: read   # required by dev-lead-reusable.yml since #435


### PR DESCRIPTION
Two fixes:

1. **`statuses: read`** — required by the reusable workflow since #435; without it the `@main`-pinned caller fails with `startup_failure`.
2. **Remove the per-repo concurrency block** — the repo-wide `'dev-lead'` group cancelled issue pickups (**7/7 `issues`-event runs cancelled**). Concurrency is now centralised in `dev-lead-reusable.yml` with per-issue/per-PR lanes (petry-projects/.github-private#450).

Stuck PR to re-trigger after merge: #230. Refs petry-projects/.github#402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)