### PR TITLE
docs: document GHAS gating behavior for secret_scanning_ai_detection

### DIFF
--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -17,6 +17,16 @@ echo "Applying security and analysis settings for: $REPO"
 # Per push-protection.md#required-repo-level-settings, every repository MUST
 # have these features enabled.  The compliance audit checks these flags via
 # GET /repos/{owner}/{repo} and reports failures as GitHub Issues.
+#
+# NOTE: `secret_scanning_ai_detection` is a GitHub Advanced Security (GHAS)
+# gated feature.  When the org has
+# `advanced_security_enabled_for_new_repositories=false`, GitHub accepts the
+# PATCH with HTTP 200 but silently omits this key from the returned
+# `security_and_analysis` object — the verification step below will report
+# `unknown` for it, and the compliance audit reads the same omitted state as
+# `null`.  The corresponding finding cannot clear from this script alone; an
+# org admin must enable GHAS at the org level before this setting can take
+# effect.  See: https://github.com/petry-projects/ContentTwin/issues/203
 
 gh api -X PATCH "repos/$REPO" --input - <<'JSON'
 {

--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -20,13 +20,14 @@ echo "Applying security and analysis settings for: $REPO"
 #
 # NOTE: `secret_scanning_ai_detection` is a GitHub Advanced Security (GHAS)
 # gated feature.  When the org has
-# `advanced_security_enabled_for_new_repositories=false`, GitHub accepts the
-# PATCH with HTTP 200 but silently omits this key from the returned
-# `security_and_analysis` object — the verification step below will report
-# `unknown` for it, and the compliance audit reads the same omitted state as
-# `null`.  The corresponding finding cannot clear from this script alone; an
-# org admin must enable GHAS at the org level before this setting can take
-# effect.  See: https://github.com/petry-projects/ContentTwin/issues/203
+# `advanced_security_enabled_for_new_repositories=false`, the PATCH above
+# succeeds with HTTP 200, but the follow-up verification GET
+# (`gh api "repos/$REPO"`, see "Verifying applied settings…" below) silently
+# omits this key from the `security_and_analysis` object — `check_setting`
+# will therefore report `unknown` for it, and the compliance audit reads the
+# same omitted state as `null`.  The corresponding finding cannot clear from
+# this script alone; an org admin must enable GHAS at the org level before
+# this setting can take effect.  See: https://github.com/petry-projects/ContentTwin/issues/203
 
 gh api -X PATCH "repos/$REPO" --input - <<'JSON'
 {


### PR DESCRIPTION
Refs #203

Documents why `secret_scanning_ai_detection` cannot be enabled by this script alone when GHAS is disabled at the org level. The underlying compliance gap (enabling GHAS org-wide) requires org-admin action tracked in #203, which remains open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced explanation of how organization-level security settings affect repository-level configuration behavior, helping users understand why certain settings may not be applied as expected in specific organizational configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->