### PR TITLE
feat: implement issue #272 — [Fleet Monitor] petry-projects/ContentTwin — .github/workflows/sonarcloud.yml

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,7 +1,5 @@
 name: SonarCloud Analysis
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 on:
   push:
     branches: [main]
@@ -19,12 +17,23 @@ jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+      # First attempt. continue-on-error lets the retry step below recover from
+      # transient 403/5xx responses from binaries.sonarsource.com (the scanner
+      # CLI download), without failing the job on a single CDN blip (#272).
       - name: SonarCloud Scan
+        id: sonar
         if: ${{ env.SONAR_TOKEN != '' }}
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        continue-on-error: true
+      - name: SonarCloud Scan (retry)
+        if: ${{ env.SONAR_TOKEN != '' && steps.sonar.outcome == 'failure' }}
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
       # First attempt. continue-on-error lets the retry step below recover from
       # transient 403/5xx responses from binaries.sonarsource.com (the scanner
       # CLI download), without failing the job on a single CDN blip (#272).

--- a/scripts/tests/sonarcloud-workflow.bats
+++ b/scripts/tests/sonarcloud-workflow.bats
@@ -59,3 +59,52 @@ print('ok')
   [ "$status" -eq 0 ]
   [[ "$output" == "ok" ]]
 }
+
+# Transient-failure retry resilience (org standard ci-standards.md #3): the scanner
+# CLI download from binaries.sonarsource.com occasionally returns transient 403/5xx.
+# A single blip must not fail the job and skew the Fleet Monitor failure rate, so the
+# first scan runs with continue-on-error and a second step retries it on failure.
+
+@test "sonarcloud runs two SonarSource scan steps" {
+  run python3 -c "
+import sys, yaml
+wf = yaml.safe_load(open(sys.argv[1]))
+steps = wf['jobs']['sonarcloud']['steps']
+scans = [s for s in steps if 'SonarSource/sonarqube-scan-action' in str(s.get('uses', ''))]
+assert len(scans) == 2, f'expected 2 SonarSource scan steps (initial + retry), got {len(scans)}'
+print('ok')
+" "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "ok" ]]
+}
+
+@test "sonarcloud first scan tolerates a transient failure" {
+  run python3 -c "
+import sys, yaml
+wf = yaml.safe_load(open(sys.argv[1]))
+steps = wf['jobs']['sonarcloud']['steps']
+scans = [s for s in steps if 'SonarSource/sonarqube-scan-action' in str(s.get('uses', ''))]
+first = scans[0]
+assert first.get('continue-on-error') is True, 'first scan must set continue-on-error: true'
+assert first.get('id'), 'first scan must have an id so the retry can read its outcome'
+print('ok')
+" "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "ok" ]]
+}
+
+@test "sonarcloud retry step is gated on the first scan failing" {
+  run python3 -c "
+import sys, yaml
+wf = yaml.safe_load(open(sys.argv[1]))
+steps = wf['jobs']['sonarcloud']['steps']
+scans = [s for s in steps if 'SonarSource/sonarqube-scan-action' in str(s.get('uses', ''))]
+first_id = scans[0].get('id')
+retry_if = str(scans[1].get('if', ''))
+assert first_id and first_id in retry_if, f'retry if must reference first scan id {first_id!r}, got: {retry_if!r}'
+assert \"outcome == 'failure'\" in retry_if, f'retry must run only on outcome == failure, got: {retry_if!r}'
+print('ok')
+" "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "ok" ]]
+}

--- a/scripts/tests/sonarcloud-workflow.bats
+++ b/scripts/tests/sonarcloud-workflow.bats
@@ -18,14 +18,15 @@ setup() {
 }
 
 @test "sonarcloud workflow is valid YAML" {
-  run python3 -c "import sys, yaml; yaml.safe_load(open('$WORKFLOW'))"
+  run python3 -c "import sys, yaml; yaml.safe_load(open('$WORKFLOW', encoding='utf-8'))"
   [ "$status" -eq 0 ]
 }
 
 @test "sonarcloud workflow declares a concurrency block" {
   run python3 -c "
 import sys, yaml
-wf = yaml.safe_load(open(sys.argv[1]))
+with open(sys.argv[1], encoding='utf-8') as f:
+  wf = yaml.safe_load(f)
 assert 'concurrency' in wf, 'workflow has no top-level concurrency block'
 c = wf['concurrency']
 assert isinstance(c, dict), 'concurrency must be a mapping with group/cancel-in-progress'
@@ -39,7 +40,8 @@ print('ok')
 @test "sonarcloud concurrency cancels in-progress runs" {
   run python3 -c "
 import sys, yaml
-wf = yaml.safe_load(open(sys.argv[1]))
+with open(sys.argv[1], encoding='utf-8') as f:
+  wf = yaml.safe_load(f)
 c = wf.get('concurrency', {})
 assert c.get('cancel-in-progress') is True, 'cancel-in-progress must be true'
 print('ok')
@@ -51,7 +53,8 @@ print('ok')
 @test "sonarcloud concurrency group is keyed per ref" {
   run python3 -c "
 import sys, yaml
-wf = yaml.safe_load(open(sys.argv[1]))
+with open(sys.argv[1], encoding='utf-8') as f:
+  wf = yaml.safe_load(f)
 group = wf.get('concurrency', {}).get('group', '')
 assert 'github.ref' in group, f'concurrency.group should key on github.ref, got: {group!r}'
 print('ok')
@@ -68,7 +71,8 @@ print('ok')
 @test "sonarcloud runs two SonarSource scan steps" {
   run python3 -c "
 import sys, yaml
-wf = yaml.safe_load(open(sys.argv[1]))
+with open(sys.argv[1], encoding='utf-8') as f:
+  wf = yaml.safe_load(f)
 steps = wf['jobs']['sonarcloud']['steps']
 scans = [s for s in steps if 'SonarSource/sonarqube-scan-action' in str(s.get('uses', ''))]
 assert len(scans) == 2, f'expected 2 SonarSource scan steps (initial + retry), got {len(scans)}'
@@ -81,7 +85,8 @@ print('ok')
 @test "sonarcloud first scan tolerates a transient failure" {
   run python3 -c "
 import sys, yaml
-wf = yaml.safe_load(open(sys.argv[1]))
+with open(sys.argv[1], encoding='utf-8') as f:
+  wf = yaml.safe_load(f)
 steps = wf['jobs']['sonarcloud']['steps']
 scans = [s for s in steps if 'SonarSource/sonarqube-scan-action' in str(s.get('uses', ''))]
 first = scans[0]
@@ -96,13 +101,14 @@ print('ok')
 @test "sonarcloud retry step is gated on the first scan failing" {
   run python3 -c "
 import sys, yaml
-wf = yaml.safe_load(open(sys.argv[1]))
+with open(sys.argv[1], encoding='utf-8') as f:
+  wf = yaml.safe_load(f)
 steps = wf['jobs']['sonarcloud']['steps']
 scans = [s for s in steps if 'SonarSource/sonarqube-scan-action' in str(s.get('uses', ''))]
 first_id = scans[0].get('id')
 retry_if = str(scans[1].get('if', ''))
 assert first_id and first_id in retry_if, f'retry if must reference first scan id {first_id!r}, got: {retry_if!r}'
-assert \"outcome == 'failure'\" in retry_if, f'retry must run only on outcome == failure, got: {retry_if!r}'
+assert 'outcome' in retry_if and 'failure' in retry_if, f'retry must run only on outcome == failure, got: {retry_if!r}'
 print('ok')
 " "$WORKFLOW"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Closes #272

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Strengthened SonarCloud workflow security by restricting GitHub Actions permissions to the minimum required.
  * Updated SonarCloud scanning to run as a two-step process: an initial scan (allowed to fail) followed by a conditional retry when the first attempt fails.

* **Tests**
  * Expanded workflow validation to cover the new two-step SonarCloud scan behavior, including retry conditions.
  * Improved workflow YAML parsing reliability in the test suite (UTF-8 handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->