### PR TITLE
chore: sync org-standard agent-shield.yml stub from petry-projects/.github

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@208ec2d69b75227d375edf8745d84fbac05a76b2 # v1


### PR DESCRIPTION
Syncs the org-standard `agent-shield.yml` workflow stub from `petry-projects/.github` (`standards/workflows/agent-shield.yml`), deployed verbatim.

Opened by `scripts/deploy-standard-workflows.sh`; the stub is a thin caller and all behaviour lives in the reusable. See `standards/ci-standards.md`.

This PR is labeled `standards-sync` and left for the normal review/auto-merge pipeline — the deploy script never merges directly.