### PR TITLE
feat: implement issue #280 — [Fleet Monitor] petry-projects/ContentTwin — .github/workflows/sonarcloud.yml

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,6 +17,13 @@ jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
+    # Backstop the whole job. A normal scan finishes in well under a minute, so a job
+    # running this long means something is wedged (e.g. a stalled checkout). Without a
+    # bound the default is 6 hours, which the Fleet Monitor records as a timed_out
+    # failure (fleet_monitor.sh). Set above the two 5-minute scan-step budgets so the
+    # per-step timeouts normally win and this stays a true backstop; under the org cap
+    # of 59 (ci-standards.md).
+    timeout-minutes: 12
     permissions:
       contents: read
       pull-requests: read
@@ -35,6 +42,11 @@ jobs:
         if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         continue-on-error: true
+        # Bound the first attempt so a hung CDN download or analysis upload fails fast
+        # (continue-on-error keeps the job alive) and the retry below can recover —
+        # rather than the hang blocking the job until the timeout-minutes backstop.
+        timeout-minutes: 5
       - name: SonarCloud Scan (retry)
         if: ${{ env.SONAR_TOKEN != '' && steps.sonar.outcome == 'failure' }}
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        timeout-minutes: 5

--- a/scripts/tests/sonarcloud-workflow.bats
+++ b/scripts/tests/sonarcloud-workflow.bats
@@ -114,3 +114,57 @@ print('ok')
   [ "$status" -eq 0 ]
   [[ "$output" == "ok" ]]
 }
+
+# Duration-bounding (issue #280): the Fleet Monitor counts a `timed_out` conclusion
+# as a failure (fleet_monitor.sh). The #272 retry only recovers from a scan step
+# that *errors*; a scan that *hangs* (CDN download or analysis upload stalls) has no
+# step timeout, so it blocks the whole job until GitHub's 6-hour default and concludes
+# `timed_out`. Bounding both the job and each scan step lets a hung first attempt fail
+# fast so the retry can still run, instead of timing out the whole job.
+
+@test "sonarcloud job declares a timeout-minutes within the org cap" {
+  run python3 -c "
+import sys, yaml
+with open(sys.argv[1], encoding='utf-8') as f:
+  wf = yaml.safe_load(f)
+job = wf['jobs']['sonarcloud']
+tm = job.get('timeout-minutes')
+assert isinstance(tm, int), f'sonarcloud job must set an integer timeout-minutes, got: {tm!r}'
+assert 1 <= tm <= 59, f'job timeout-minutes must be within the org cap 1..59, got: {tm}'
+print('ok')
+" "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "ok" ]]
+}
+
+@test "sonarcloud both scan steps declare a timeout-minutes" {
+  run python3 -c "
+import sys, yaml
+with open(sys.argv[1], encoding='utf-8') as f:
+  wf = yaml.safe_load(f)
+steps = wf['jobs']['sonarcloud']['steps']
+scans = [s for s in steps if 'SonarSource/sonarqube-scan-action' in str(s.get('uses', ''))]
+for i, s in enumerate(scans):
+  tm = s.get('timeout-minutes')
+  assert isinstance(tm, int) and tm >= 1, f'scan step {i} must set an integer timeout-minutes >= 1, got: {tm!r}'
+print('ok')
+" "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "ok" ]]
+}
+
+@test "sonarcloud first scan timeout leaves room for the retry within the job budget" {
+  run python3 -c "
+import sys, yaml
+with open(sys.argv[1], encoding='utf-8') as f:
+  wf = yaml.safe_load(f)
+job = wf['jobs']['sonarcloud']
+job_tm = job['timeout-minutes']
+scans = [s for s in job['steps'] if 'SonarSource/sonarqube-scan-action' in str(s.get('uses', ''))]
+first_tm = scans[0]['timeout-minutes']
+assert first_tm < job_tm, f'first scan timeout ({first_tm}) must be < job timeout ({job_tm}) so a hung first attempt fails fast and the retry can run'
+print('ok')
+" "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "ok" ]]
+}

--- a/scripts/tests/sonarcloud-workflow.bats
+++ b/scripts/tests/sonarcloud-workflow.bats
@@ -144,6 +144,7 @@ with open(sys.argv[1], encoding='utf-8') as f:
   wf = yaml.safe_load(f)
 steps = wf['jobs']['sonarcloud'].get('steps', [])
 scans = [s for s in steps if 'SonarSource/sonarqube-scan-action' in str(s.get('uses', ''))]
+assert len(scans) == 2, f'expected exactly 2 Sonar scan steps, got: {len(scans)}'
 for i, s in enumerate(scans):
   tm = s.get('timeout-minutes')
   assert isinstance(tm, int) and tm >= 1, f'scan step {i} must set an integer timeout-minutes >= 1, got: {tm!r}'

--- a/scripts/tests/sonarcloud-workflow.bats
+++ b/scripts/tests/sonarcloud-workflow.bats
@@ -142,7 +142,7 @@ print('ok')
 import sys, yaml
 with open(sys.argv[1], encoding='utf-8') as f:
   wf = yaml.safe_load(f)
-steps = wf['jobs']['sonarcloud']['steps']
+steps = wf['jobs']['sonarcloud'].get('steps', [])
 scans = [s for s in steps if 'SonarSource/sonarqube-scan-action' in str(s.get('uses', ''))]
 for i, s in enumerate(scans):
   tm = s.get('timeout-minutes')
@@ -159,9 +159,10 @@ import sys, yaml
 with open(sys.argv[1], encoding='utf-8') as f:
   wf = yaml.safe_load(f)
 job = wf['jobs']['sonarcloud']
-job_tm = job['timeout-minutes']
-scans = [s for s in job['steps'] if 'SonarSource/sonarqube-scan-action' in str(s.get('uses', ''))]
-first_tm = scans[0]['timeout-minutes']
+job_tm = job.get('timeout-minutes')
+scans = [s for s in job.get('steps', []) if 'SonarSource/sonarqube-scan-action' in str(s.get('uses', ''))]
+first_tm = scans[0].get('timeout-minutes') if scans else None
+assert isinstance(job_tm, int) and isinstance(first_tm, int), 'timeouts must be integers'
 assert first_tm < job_tm, f'first scan timeout ({first_tm}) must be < job timeout ({job_tm}) so a hung first attempt fails fast and the retry can run'
 print('ok')
 " "$WORKFLOW"


### PR DESCRIPTION
Closes #280

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for SonarCloud workflow timeout configuration.

* **Chores**
  * Enhanced SonarCloud workflow reliability by adding explicit timeout limits to prevent scans from stalling, including a 12-minute job timeout and 5-minute timeout boundaries for scan attempts with retry logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->