### PR TITLE
chore: sync 6 org-standard workflow stub(s) from petry-projects/.github

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@agent-shield/stable

--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@agent-shield/stable
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # agent-shield/stable

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -50,5 +50,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/stable
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # auto-rebase/stable
     secrets: inherit

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -6,9 +6,11 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All branch-update logic lives in the
 #     reusable workflow above.
-#   • You MAY change: the SHA in the `uses:` line when upgrading the reusable
-#     workflow version (bump SHA to latest main of petry-projects/.github).
-#   • You MUST NOT change: trigger event, the concurrency group name,
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `auto-rebase/stable` channel, a moving tag advanced centrally. Never
+#     repoint it to `@main`, a SHA, or a frozen `@vX` (see ci-standards.md →
+#     Reusable workflow versioning). Also do not change the trigger event,
+#     the concurrency group name,
 #     or the job-level `permissions:` block — reusable workflows can be
 #     granted no more permissions than the calling job has, so removing
 #     the stanza breaks the reusable's gh API calls.
@@ -19,6 +21,16 @@
 # Auto-rebase non-Dependabot PRs — thin caller for the org-level reusable.
 # To adopt: copy this file to .github/workflows/auto-rebase.yml in your repo.
 # No secrets required — uses GITHUB_TOKEN only.
+#
+# By default the reusable only updates *review-ready* PRs: non-draft AND
+# (carrying a current APPROVED review OR the `auto-rebase:ready` label). This
+# keeps the workflow from fanning out branch-update CI runs to every behind PR.
+# To tune it, pass inputs to the reusable, e.g.:
+#
+#   with:
+#     eligibility: review-ready      # default; or `all` to update every behind PR
+#     ready_label: auto-rebase:ready # label that opts a non-draft PR in
+#
 name: Auto-rebase non-Dependabot PRs
 
 on:
@@ -38,5 +50,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@d3d768dabb7f28cc63283cdfe48630da53700e50 # v1
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/stable
     secrets: inherit

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -6,10 +6,9 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All branch-update logic lives in the
 #     reusable workflow above.
-#   • You MUST NOT change: the `uses:` ref — it is pinned to the
-#     `auto-rebase/stable` channel, a moving tag advanced centrally. Never
-#     repoint it to `@main`, a SHA, or a frozen `@vX` (see ci-standards.md →
-#     Reusable workflow versioning). Also do not change the trigger event,
+#   • You MUST NOT change: the `uses:` ref in caller repos. It is managed by
+#     standards sync and pinned to a reviewed commit SHA (annotated with the
+#     `auto-rebase/stable` channel intent). Also do not change the trigger event,
 #     the concurrency group name,
 #     or the job-level `permissions:` block — reusable workflows can be
 #     granted no more permissions than the calling job has, so removing

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/stable
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # dependabot-automerge/stable
     secrets: inherit

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,27 +1,26 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-automerge.yml
-# Standard: petry-projects/.github/standards/dependabot-policy.md
-# Reusable: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml
+# Standard:        petry-projects/.github/standards/dependabot-policy.md
+# Reusable:        petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
-# • This file is a THIN CALLER STUB. All eligibility logic and the GitHub
-# App token dance live in the reusable workflow above.
-# • You MAY change: nothing in this file in normal use. Adopt verbatim.
-# • You MUST NOT change: trigger event (must be `pull_request_target`),
-# the `uses:` line, `secrets: inherit`, or the job-level `permissions:`
-# block — reusable workflows can be granted no more permissions than the
-# calling job has, so removing the stanza breaks the reusable's gh API
-# calls.
-# • If you need different behaviour, open a PR against the reusable in the
-# central repo.
+#   • This file is a THIN CALLER STUB. All eligibility logic and the GitHub
+#     App token dance live in the reusable workflow above.
+#   • You MAY change: nothing in this file in normal use. Adopt verbatim.
+#   • You MUST NOT change: trigger event (must be `pull_request_target`),
+#     the `uses:` line, `secrets: inherit`, or the job-level `permissions:`
+#     block — reusable workflows can be granted no more permissions than the
+#     calling job has, so removing the stanza breaks the reusable's gh API
+#     calls.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo.
 # ─────────────────────────────────────────────────────────────────────────────
 #
 # Dependabot auto-merge — thin caller for the org-level reusable.
 # To adopt: copy this file to .github/workflows/dependabot-automerge.yml in your repo.
 # Required org/repo secrets (inherited):
-# APP_ID — GitHub App ID with contents:write and pull-requests:write
-# APP_PRIVATE_KEY — GitHub App private key
-
+#   APP_ID         — GitHub App ID with contents:write and pull-requests:write
+#   APP_PRIVATE_KEY — GitHub App private key
 name: Dependabot auto-merge
 
 on:
@@ -36,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v2
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/stable
     secrets: inherit

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -50,7 +50,7 @@ jobs:
     permissions:
       contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write  # re-approve PRs after branch update
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@dependabot-rebase/stable
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # dependabot-rebase/stable
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -1,30 +1,34 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-rebase.yml
-# Standard: petry-projects/.github/standards/dependabot-policy.md
-# Reusable: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml
+# Standard:        petry-projects/.github/standards/dependabot-policy.md
+# Reusable:        petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
-# • This file is a THIN CALLER STUB. All rebase/merge serialization logic
-# lives in the reusable workflow above.
-# • You MAY change: the ref in the `uses:` line when upgrading the reusable
-# workflow version (bump to latest commit SHA or tag of petry-projects/.github).
-# • You MUST NOT change: the concurrency group name, the explicit secrets
-# block, or the job-level `permissions:` block — reusable workflows can be
-# granted no more permissions than the calling job has, so removing the
-# stanza breaks the reusable's gh API calls. Do not remove any trigger
-# (`push` keeps the self-sustaining chain; `schedule` is the safety net
-# when no PR merges have occurred recently; `workflow_dispatch` allows
-# manual queue flushes).
-# • If you need different behaviour, open a PR against the reusable in the
-# central repo.
+#   • This file is a THIN CALLER STUB. All rebase/merge serialization logic
+#     lives in the reusable workflow above.
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `dependabot-rebase/stable` channel, a moving tag advanced centrally.
+#     Never repoint it to `@main`, a SHA, or a frozen `@vX` (see
+#     ci-standards.md → Reusable workflow versioning). Also do not change the
+#     concurrency group name, the explicit secrets
+#     block, or the job-level `permissions:` block — reusable workflows can be
+#     granted no more permissions than the calling job has, so removing the
+#     stanza breaks the reusable's gh API calls. Do not remove any trigger
+#     (`push` keeps the self-sustaining chain; `schedule` is the safety net
+#     when no PR merges have occurred recently; `workflow_dispatch` allows
+#     manual queue flushes).
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo.
 # ─────────────────────────────────────────────────────────────────────────────
 #
 # Dependabot update-and-merge — thin caller for the org-level reusable.
-# To adopt: copy this file to .github/workflows/dependabot-rebase.yml in your repo.
-# Required org secrets (passed explicitly):
-# APP_ID — GitHub App ID with contents:write and pull-requests:write
-# APP_PRIVATE_KEY — GitHub App private key
-
+# To adopt: copy THIS file (standards/workflows/dependabot-rebase.yml) to
+#   .github/workflows/dependabot-rebase.yml in your repo. Do NOT copy
+#   .github/workflows/dependabot-rebase.yml from this repo — that file uses a
+#   local ref only valid in the source-of-truth repo.
+# Required org/repo secrets (inherited):
+#   APP_ID         — GitHub App ID with contents:write and pull-requests:write
+#   APP_PRIVATE_KEY — GitHub App private key
 name: Dependabot update and merge
 
 on:
@@ -44,8 +48,9 @@ permissions: {}
 jobs:
   dependabot-rebase:
     permissions:
-      pull-requests: write # call update-branch API on behind PRs and merge when ready
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@73231f6f9c38330157ba15a0c05157c505cab00d # v1
+      contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
+      pull-requests: write  # re-approve PRs after branch update
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@dependabot-rebase/stable
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/stable

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/stable
+    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # dependency-audit/stable

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -1,3 +1,26 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/pr-review-mention.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All review-dispatch logic lives in the
+#     reusable workflow above.
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `pr-review-mention/stable` channel, a moving tag advanced centrally.
+#     Never repoint it to `@main`, a SHA, or a frozen `@vX` (see
+#     ci-standards.md → Reusable workflow versioning). Also do not change the
+#     trigger events or the job-level `permissions:` block — reusable workflows
+#     can be granted no more permissions than the calling job, so removing the
+#     stanza breaks the reusable's gh API calls.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo. A new release is rolled out by moving the channel tag
+#     centrally — never by editing callers, so no fanout PR is needed.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# PR Review Mention — thin caller for the org-level reusable.
+# To adopt: copy this file to .github/workflows/pr-review-mention.yml in your repo.
+# Requires: GH_PAT_WORKFLOWS org secret (already present in petry-projects org).
 name: PR Review — Mention Trigger
 
 on:
@@ -14,6 +37,5 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v2
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/stable
     secrets: inherit
-

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -37,5 +37,5 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/stable
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # pr-review-mention/stable
     secrets: inherit


### PR DESCRIPTION
Syncs the following org-standard workflow stub(s) from `petry-projects/.github` (`standards/workflows/`), deployed verbatim:

- `pr-review-mention.yml`
- `agent-shield.yml`
- `auto-rebase.yml`
- `dependabot-automerge.yml`
- `dependabot-rebase.yml`
- `dependency-audit.yml`

Opened by `scripts/deploy-standard-workflows.sh`. Stubs are thin callers; all behaviour lives in the reusables. See `standards/ci-standards.md`. Labeled `standards-sync` and left for the normal review/auto-merge pipeline — the deploy script never merges directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD infrastructure workflows for enhanced stability and maintainability across deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->