### PR TITLE
chore: repin centralized stubs to their stable channel tags (#482)

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # agent-shield/stable
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@agent-shield/stable

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -49,5 +49,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # auto-rebase/stable
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/stable
     secrets: inherit

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # dependabot-automerge/stable
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/stable
     secrets: inherit

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -50,7 +50,7 @@ jobs:
     permissions:
       contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write  # re-approve PRs after branch update
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # dependabot-rebase/stable
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@dependabot-rebase/stable
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -38,4 +38,4 @@ concurrency:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # dependency-audit/stable
+    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/stable

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -37,5 +37,5 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # pr-review-mention/stable
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/stable
     secrets: inherit

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,38 @@ sonar.projectKey=petry-projects_ContentTwin
 sonar.organization=petry-projects
 sonar.projectName=ContentTwin
 sonar.sources=.
-sonar.exclusions=_bmad/**,_bmad-output/**,.claude/**,.github/workflows/agent-shield.yml,.github/workflows/auto-rebase.yml,.github/workflows/dependabot-automerge.yml,.github/workflows/dependabot-rebase.yml,.github/workflows/dependency-audit.yml,.github/workflows/pr-review-mention.yml
+sonar.exclusions=_bmad/**,_bmad-output/**,.claude/**
+
+# SonarCloud S7637 exemption for first-party reusable-ref caller stubs (#482).
+# These thin caller stubs contain ONLY a petry-projects/.github(-private)
+# reusable `uses:` ref, pinned to a moving channel/tag (`@<name>/stable`) by org
+# standard — intentionally NOT SHA-pinned (Action Pinning Policy exemption #239).
+# Suppress S7637 per stub file via the rule (mirrors petry-projects/.github's
+# config) — a blanket `sonar.exclusions` only quiets the quality gate, not the
+# code-scanning SARIF, so the GitHub-Advanced-Security "SonarCloud" check still
+# fails on the new alerts. Third-party `uses:` keep full SHA-pin enforcement.
+sonar.issue.ignore.multicriteria=s7637_agentshield,s7637_prreviewmention,s7637_autorebase,s7637_dependabotrebase,s7637_dependabotautomerge,s7637_dependencyaudit,s7637_devlead,s7637_addtoproject
+
+sonar.issue.ignore.multicriteria.s7637_agentshield.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.s7637_agentshield.resourceKey=**/agent-shield.yml
+
+sonar.issue.ignore.multicriteria.s7637_prreviewmention.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.s7637_prreviewmention.resourceKey=**/pr-review-mention.yml
+
+sonar.issue.ignore.multicriteria.s7637_autorebase.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.s7637_autorebase.resourceKey=**/auto-rebase.yml
+
+sonar.issue.ignore.multicriteria.s7637_dependabotrebase.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.s7637_dependabotrebase.resourceKey=**/dependabot-rebase.yml
+
+sonar.issue.ignore.multicriteria.s7637_dependabotautomerge.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.s7637_dependabotautomerge.resourceKey=**/dependabot-automerge.yml
+
+sonar.issue.ignore.multicriteria.s7637_dependencyaudit.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.s7637_dependencyaudit.resourceKey=**/dependency-audit.yml
+
+sonar.issue.ignore.multicriteria.s7637_devlead.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.s7637_devlead.resourceKey=**/dev-lead.yml
+
+sonar.issue.ignore.multicriteria.s7637_addtoproject.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.s7637_addtoproject.resourceKey=**/add-to-project.yml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,4 @@ sonar.projectKey=petry-projects_ContentTwin
 sonar.organization=petry-projects
 sonar.projectName=ContentTwin
 sonar.sources=.
-sonar.exclusions=_bmad/**,_bmad-output/**,.claude/**
+sonar.exclusions=_bmad/**,_bmad-output/**,.claude/**,.github/workflows/agent-shield.yml,.github/workflows/auto-rebase.yml,.github/workflows/dependabot-automerge.yml,.github/workflows/dependabot-rebase.yml,.github/workflows/dependency-audit.yml,.github/workflows/pr-review-mention.yml


### PR DESCRIPTION
Repins ContentTwin's 6 `.github`-hosted reusable stubs from a frozen SHA (`@376a4fcb # <name>/stable`) to the moving `@<name>/stable` channel tags used by the rest of the stable-tier fleet.

A SHA pin silently opts the repo out of channel promotions and diverges from the canonical pin (#239 exempts internal reusable refs from SHA-pinning), so both the ring-aware compliance audit and the deploy sweep flag it. **Zero-change today** (stable resolves to 376a4fcb) but ContentTwin now tracks `stable` like its peers.

Refs #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)