### PR TITLE
ci: deploy feature-ideation caller stub (@feature-ideation/stable)

### DIFF
--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -1,0 +1,127 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/feature-ideation.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md#8-feature-ideation-feature-ideationyml--bmad-method-repos
+# Reusable:        petry-projects/.github/.github/workflows/feature-ideation-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. The 5-phase ideation pipeline, the
+#     Opus 4.6 model selection, the github_token override, and the
+#     ANTHROPIC_MODEL env var all live in the reusable workflow above.
+#   • You MAY change: the `project_context` value (the only required edit
+#     per repo), and optionally the cron schedule.
+#   • You MUST NOT change: trigger event shape, the `uses:` line, the
+#     job-level `permissions:` block, or the `secrets:` block — these are
+#     required for the reusable to work.
+#   • If you need different behaviour, open a PR against the reusable in
+#     the central repo. The change will propagate everywhere on next run.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Feature Ideation workflow stub — for BMAD Method-enabled repos.
+#
+# This is a thin caller for the org-wide reusable workflow at
+# petry-projects/.github/.github/workflows/feature-ideation-reusable.yml
+# All ideation logic, the multi-skill pipeline, the Opus 4.6 model
+# selection, and the github_token override live in the reusable workflow.
+#
+# To adopt:
+#   1. Copy this file to .github/workflows/feature-ideation.yml in your repo.
+#   2. Replace the `project_context` value with a 3-5 sentence description
+#      of your project, its target users, and the competitive landscape Mary
+#      should research. This is the only required customisation.
+#   3. (Optional) Copy standards/feature-ideation-sources.md from
+#      petry-projects/.github to .github/feature-ideation-sources.md in your
+#      repo and trim/extend it for your project. Mary uses YOUR copy — not the
+#      central template — so each repo controls its own source list.
+#      Pass `sources_file: path/to/your-list.md` to the reusable workflow if
+#      you prefer a different location.
+#   4. (Optional) Adjust the schedule cron if Friday morning UTC doesn't suit.
+#   5. Ensure GitHub Discussions is enabled with an "Ideas" category.
+#   6. Confirm the org-level secret CLAUDE_CODE_OAUTH_TOKEN is accessible.
+#
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#8-feature-ideation-feature-ideationyml--bmad-method-repos
+name: Feature Research & Ideation (BMAD Analyst)
+
+on:
+  schedule:
+    - cron: '0 7 * * 5' # Friday 07:00 UTC (3 AM EDT / 2 AM EST)
+  workflow_dispatch:
+    inputs:
+      focus_area:
+        description: 'Optional focus area (e.g., "accessibility", "performance")'
+        required: false
+        type: string
+      research_depth:
+        description: 'Research depth'
+        required: false
+        default: 'standard'
+        type: choice
+        options:
+          - quick
+          - standard
+          - deep
+      dry_run:
+        description: 'Skip Discussion mutations and log them to a JSONL artifact instead. Use this on a fork to smoke-test before going live.'
+        required: false
+        default: false
+        type: boolean
+  # Auto-enhance a freshly-created idea: when a new Discussion is opened in the
+  # Ideas category, the analyst researches and refines it in single-idea mode.
+  discussion:
+    types: [created]
+
+permissions: {}
+
+concurrency:
+  group: feature-ideation
+  cancel-in-progress: false
+
+jobs:
+  ideate:
+    # On the `discussion` trigger, only run for new ideas in the Ideas category
+    # and skip the bot's own creations (avoids re-enhancing scheduled output;
+    # enhancement posts a comment, which does not re-fire `discussion: created`).
+    # Schedule/dispatch runs are unaffected by this guard.
+    if: >-
+      github.event_name != 'discussion' ||
+      (github.event.discussion.category.slug == 'ideas' &&
+       github.event.discussion.user.type != 'Bot')
+    # Permissions cascade from the calling job to the reusable workflow.
+    # The reusable workflow's two jobs (gather-signals + analyze) need:
+    #   - contents:      read   (checkout, file reads)
+    #   - issues:        read   (signal collection)
+    #   - pull-requests: read   (signal collection)
+    #   - discussions:   write  (CRITICAL — create/update Discussion threads)
+    #   - id-token:      write  (claude-code-action OIDC for GitHub App token)
+    #   - actions:       read   (feed checkpoint — last successful run query)
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      discussions: write
+      id-token: write
+      actions: read
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    with:
+      # On the `discussion: created` trigger this carries the new Discussion's
+      # number → the reusable runs single-idea enhancement mode. Empty on
+      # schedule/dispatch → normal scan. Do not edit this line.
+      target_discussion: ${{ github.event.discussion.number }}
+      # === CUSTOMISE THIS PER REPO — the only required edit ===
+      # Replace this paragraph with a 3-5 sentence description of your project,
+      # its target users, and the competitive landscape. The more specific you
+      # are, the more useful the proposals.
+      project_context: |
+        TODO: Replace this with a description of the project and its market.
+        Example: "ProjectX is a [type of product] for [target user]. Competitors
+        include A, B, C. Key emerging trends in this space: X, Y, Z."
+      # === OPTIONAL: repo-local reputable source list ===
+      # Copy standards/feature-ideation-sources.md from petry-projects/.github
+      # to .github/feature-ideation-sources.md and customise it. The reusable
+      # workflow defaults to that path, so you only need to uncomment and change
+      # sources_file below if you store the list somewhere else.
+      # sources_file: 'docs/feature-ideation-sources.md'
+      focus_area: ${{ inputs.focus_area || '' }}
+      research_depth: ${{ inputs.research_depth || 'standard' }}
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Closes the coverage gap — ContentTwin was the only fully-onboarded consumer missing feature-ideation. Adds the standard caller stub pinned to the stable channel (`@feature-ideation/stable`), matching the other stable-tier repos (google-app-scripts, broodly, markets).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated feature research and ideation workflow.
  * Supports scheduled runs, manual launches with configurable focus and research depth, and idea discussion events.
  * Can enhance newly created human-submitted ideas and optionally perform dry runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->