### PR TITLE
chore: sync 8 org-standard workflow stub(s) from petry-projects/.github

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -16,9 +16,10 @@
 #   • If you need different behaviour, open a PR against the reusable.
 # ─────────────────────────────────────────────────────────────────────────────
 #
-# Auto-add this repo's qualifying issues, PRs, and Ideas-category discussions
-# to the org-level Initiatives project
-# (https://github.com/orgs/petry-projects/projects/1).
+# Track this repo's issues (all, un-gated) and dev-lead-labeled PRs on the
+# org-level Initiatives project
+# (https://github.com/orgs/petry-projects/projects/1). Ideas live in
+# Discussions and are not tracked here.
 #
 # To adopt: copy this file to .github/workflows/add-to-project.yml in your
 # repo. Requires the org secrets INITIATIVES_APP_ID and
@@ -26,7 +27,6 @@
 # app installation must include this repo. See petry-projects/.github#387.
 #
 # Tracking: petry-projects/.github#387, #415
-# Discussion: petry-projects/.github#386
 name: Auto-add to Initiatives project
 
 on:
@@ -34,16 +34,12 @@ on:
     types: [opened, labeled, unlabeled, reopened]
   pull_request_target:
     types: [opened, labeled, unlabeled, reopened, ready_for_review]
-  discussion:
-    types: [created, category_changed, deleted, transferred]
 
 permissions: {}
 
 concurrency:
   group: >-
-    add-to-project-${{ github.event_name == 'discussion'
-    && format('disc-{0}', github.event.discussion.number)
-    || format('{0}-{1}', github.event_name,
+    add-to-project-${{ format('{0}-{1}', github.event_name,
        github.event.issue.number || github.event.pull_request.number) }}
   cancel-in-progress: false
 

--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@agent-shield/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@agent-shield/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -6,9 +6,10 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All branch-update logic lives in the
 #     reusable workflow above.
-#   • You MUST NOT change: the `uses:` ref in caller repos. It is managed by
-#     standards sync and pinned to a reviewed commit SHA (annotated with the
-#     `auto-rebase/stable` channel intent). Also do not change the trigger event,
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `auto-rebase/stable` channel, a moving tag advanced centrally. Never
+#     repoint it to `@main`, a SHA, or a frozen `@vX` (see ci-standards.md →
+#     Reusable workflow versioning). Also do not change the trigger event,
 #     the concurrency group name,
 #     or the job-level `permissions:` block — reusable workflows can be
 #     granted no more permissions than the calling job has, so removing
@@ -49,5 +50,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -50,7 +50,7 @@ jobs:
     permissions:
       contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write  # re-approve PRs after branch update
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@dependabot-rebase/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@dependabot-rebase/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -28,6 +28,14 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded in-progress run on the same ref so a new push/PR commit
+# doesn't race an older run — trims redundant concurrent runs (issue #264).
+# Caller-local reliability addition; mirrors ci.yml. Does not alter the trigger
+# events, the `uses:` line, or the job name (the required status check).
+concurrency:
+  group: dependency-audit-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-audit:
     uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,6 +1,6 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependency-audit.yml
-# Standard:        petry-projects/.github/standards/ci-standards.md#5-dependency-audit-dependency-auditym
+# Standard:        petry-projects/.github/standards/ci-standards.md#7-dependency-audit-dependency-audityml
 # Reusable:        petry-projects/.github/.github/workflows/dependency-audit-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
@@ -28,14 +28,6 @@ on:
 permissions:
   contents: read
 
-# Cancel a superseded in-progress run on the same ref so a new push/PR commit
-# doesn't race an older run — trims redundant concurrent runs (issue #264).
-# Caller-local reliability addition; mirrors ci.yml. Does not alter the trigger
-# events, the `uses:` line, or the job name (the required status check).
-concurrency:
-  group: dependency-audit-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -8,9 +8,22 @@
 #   2. Ensure CLAUDE_CODE_OAUTH_TOKEN is set as an org or repo secret.
 #   3. Optionally set GH_PAT_WORKFLOWS (required if Claude pushes workflow files).
 #   4. Optionally set vars.DEV_LEAD_ENGINE = "claude" | "gemini" | "copilot".
+#   5. SonarCloud-gated repo? Nothing to do — the `uses:` line below already
+#      carries the inline `# NOSONAR(githubactions:S7637)` marker. The ref is a
+#      first-party reusable pinned to a moving channel/ring tag, so without the
+#      marker SonarCloud's githubactions:S7637 would fail the Quality Gate. The
+#      marker travels with this file on copy; no sonar-project.properties entry
+#      is needed. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#sonarcloud-exemption-first-party-reusable-ref-s7637.
 #
-# UNLIKE claude.yml, this file has NO OIDC byte-for-byte constraint and may be
-# freely modified on PR branches to adjust triggers for repo-specific needs.
+# This stub is copied VERBATIM and is full-file identical across every adopting
+# repo, modulo the per-repo ring/channel pin on the `uses:` ref and its matching
+# `agent_ref` (below). Any other diff is drift, not a repo-specific liberty:
+# `on:`, `permissions:`, and `concurrency:` are NOT repo-adjustable — do not trim
+# a trigger, narrow a permission, or add a concurrency block on a PR branch. The
+# behavior lives in the reusable, so change it there (or via a standards PR) and
+# let the channel tag promote it centrally — never by editing this caller. See
+# https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#centralization-tiers and
+# https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#reusable-workflow-versioning--the-stable-channel.
 #
 # REQUIRED secrets: CLAUDE_CODE_OAUTH_TOKEN
 # OPTIONAL secrets: GH_PAT_WORKFLOWS, GOOGLE_API_KEY, GH_PAT
@@ -43,9 +56,14 @@ permissions: {}
 
 jobs:
   dev-lead:
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    # Pinned to the moving dev-lead/stable channel tag, not @main, so a broken
+    # change to dev-lead can no longer gate its own fix (the self-host circular
+    # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
+    # caller is never edited on release. agent_ref threads the same channel into
+    # dev-lead's own scripts/prompts checkout. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#dev-lead-agent.
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
-      agent_ref: dev-lead/stable
+      agent_ref: dev-lead/v1-stable
     secrets: inherit
     permissions:
       contents: write
@@ -53,4 +71,4 @@ jobs:
       issues: write
       actions: read
       checks: read
-      statuses: read   # required by dev-lead-reusable.yml since #435
+      statuses: read

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -33,9 +33,21 @@ on:
 
 permissions: {}
 
+# Collapse superseded runs on the same PR/issue conversation. Near-simultaneous
+# comment and review-request events (e.g. multiple review comments posted at once
+# by the bot) would otherwise each spawn a caller run; the superseded ones get
+# held pending approval (action_required) and inflate the Fleet Monitor failure
+# rate (#323). Mirrors the fix applied to pr-auto-review.yml in #274. The group
+# keys on the PR/issue number so runs on unrelated conversations are not
+# cross-cancelled — github.ref is the default branch for comment events, so it is
+# only a last-resort fallback here.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -20,7 +20,7 @@
 #
 # PR Review Mention — thin caller for the org-level reusable.
 # To adopt: copy this file to .github/workflows/pr-review-mention.yml in your repo.
-# Requires: GH_PAT_WORKFLOWS and DON_PETRY_BOT_GH_PAT org secrets (already present in petry-projects org).
+# Requires: GH_PAT_WORKFLOWS org secret (already present in petry-projects org).
 name: PR Review — Mention Trigger
 
 on:
@@ -33,21 +33,9 @@ on:
 
 permissions: {}
 
-# Collapse superseded runs on the same PR/issue conversation. Near-simultaneous
-# comment and review-request events (e.g. multiple review comments posted at once
-# by the bot) would otherwise each spawn a caller run; the superseded ones get
-# held pending approval (action_required) and inflate the Fleet Monitor failure
-# rate (#323). Mirrors the fix applied to pr-auto-review.yml in #274. The group
-# keys on the PR/issue number so runs on unrelated conversations are not
-# cross-cancelled — github.ref is the default branch for comment events, so it is
-# only a last-resort fallback here.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit


### PR DESCRIPTION
Syncs the following org-standard workflow stub(s) from `petry-projects/.github` (`standards/workflows/`), deployed verbatim:

- `pr-review-mention.yml`
- `dev-lead.yml`
- `agent-shield.yml`
- `auto-rebase.yml`
- `dependabot-automerge.yml`
- `dependabot-rebase.yml`
- `dependency-audit.yml`
- `add-to-project.yml`

Opened by `scripts/deploy-standard-workflows.sh`. Stubs are thin callers; all behaviour lives in the reusables. See `standards/ci-standards.md`. Labeled `standards-sync` and left for the normal review/auto-merge pipeline — the deploy script never merges directly.