### PR TITLE
fix: re-pin agent_ref inputs to v-form (missed by #657 uses:-only re-pin)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -51,7 +51,7 @@ jobs:
     with:
       project_id: PVT_kwDOD2inqs4BZq3-
       project_url: https://github.com/orgs/petry-projects/projects/1
-      agent_ref: add-to-project/stable
+      agent_ref: add-to-project/v1-stable
     # Pass only the secrets the reusable declares (least privilege; avoids
     # `secrets: inherit` handing the reusable every org secret).
     secrets:


### PR DESCRIPTION
The #657 migration re-pinned `uses:` refs to `@<agent>/v<M>-<tier>` but MISSED the `agent_ref:` inputs (no `@` prefix), which the reusable uses to checkout its tooling at that channel. Retiring the bare tags broke dev-lead (checkout of the deleted bare tag). This re-pins agent_ref to match. Unblocks safe bare-tag retirement. #657 / gap #704.