### PR TITLE
chore: set feature-ideation project_context to enable ideation

### DIFF
--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -111,9 +111,18 @@ jobs:
       # its target users, and the competitive landscape. The more specific you
       # are, the more useful the proposals.
       project_context: |
-        TODO: Replace this with a description of the project and its market.
-        Example: "ProjectX is a [type of product] for [target user]. Competitors
-        include A, B, C. Key emerging trends in this space: X, Y, Z."
+        ContentTwin is an AI-powered social media agent that gives small
+        organizations — non-profits, community groups, and small businesses —
+        an enterprise-quality social presence at non-profit pricing. It
+        autonomously drafts, schedules, and adapts on-brand content across the
+        major platforms so lean teams with no dedicated marketer can stay
+        consistently active. Target users are budget-constrained organizations
+        that cannot afford an agency or a full-time social manager. Competitors
+        include Buffer, Hootsuite, Later, Sprout Social, and AI copy tools such
+        as Jasper and Copy.ai. Emerging trends in this space: agentic
+        multi-platform automation, brand-voice fine-tuning, the dominance of
+        short-form video/Reels, and volatile platform APIs and ranking
+        algorithms.
       # === OPTIONAL: repo-local reputable source list ===
       # Copy standards/feature-ideation-sources.md from petry-projects/.github
       # to .github/feature-ideation-sources.md and customise it. The reusable


### PR DESCRIPTION
## What

Fills in the `project_context` in this repo's `feature-ideation.yml` caller stub with a real 3–5 sentence description of the project, its target users, and the competitive landscape.

Summary: **AI-powered social media agent for small orgs / non-profits**.

## Why

The stub still carried the stock `TODO: Replace this…` placeholder. The reusable workflow's **"Validate project_context is customised"** guard greps for that exact string and `exit 1`s, so **every scheduled Friday run has been failing** and the repo has produced no (or stale) Ideas Discussions:

- ContentTwin — never succeeded (0 Ideas Discussions)
- markets & google-app-scripts — last success 2026-04-07, failing every run since ~June

With a real `project_context`, the guard passes and Mary (the BMAD analyst) can run the broad ideation scan. After merge, I'll dispatch a run to verify.

Context sourced from the repo description / README / BMAD planning artifacts and the repo's prior April ideation output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated feature ideation context with details about ContentTwin, including its target users, competitors, and relevant market trends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->