### PR TITLE
feat: implement issue #343 — Compliance: stub-surface-drift-dependency-audit.yml-concurrency

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -28,6 +28,14 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded in-progress run on the same ref so a new push/PR commit
+# doesn't race an older run — trims redundant concurrent runs (issue #264).
+# Caller-local reliability addition; mirrors ci.yml. Does not alter the trigger
+# events, the `uses:` line, or the job name (the required status check).
+concurrency:
+  group: dependency-audit-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-audit:
     uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -28,14 +28,6 @@ on:
 permissions:
   contents: read
 
-# Cancel a superseded in-progress run on the same ref so a new push/PR commit
-# doesn't race an older run — trims redundant concurrent runs (issue #264).
-# Caller-local reliability addition; mirrors ci.yml. Does not alter the trigger
-# events, the `uses:` line, or the job name (the required status check).
-concurrency:
-  group: dependency-audit-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   dependency-audit:
     uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -28,10 +28,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   dependency-audit:
     uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -28,6 +28,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-audit:
     uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/scripts/tests/dependency-audit-workflow.bats
+++ b/scripts/tests/dependency-audit-workflow.bats
@@ -72,26 +72,11 @@ print('ok')
   [[ "$output" == "ok" ]]
 }
 
-@test "concurrency group is defined" {
+@test "no caller-local concurrency block (delegated to reusable)" {
   run python3 -c "
 import sys, yaml
 wf = yaml.safe_load(open(sys.argv[1]))
-assert 'concurrency' in wf, 'workflow has no top-level concurrency block'
-c = wf['concurrency']
-assert isinstance(c, dict), 'concurrency must be a mapping'
-assert c.get('group'), 'concurrency.group must be set'
-print('ok')
-" "$WORKFLOW"
-  [ "$status" -eq 0 ]
-  [[ "$output" == "ok" ]]
-}
-
-@test "concurrency cancels superseded in-progress runs" {
-  run python3 -c "
-import sys, yaml
-wf = yaml.safe_load(open(sys.argv[1]))
-c = wf.get('concurrency', {})
-assert c.get('cancel-in-progress') is True, 'cancel-in-progress must be true'
+assert 'concurrency' not in wf, 'stub must not define a caller-local concurrency block — concurrency is owned by the reusable workflow'
 print('ok')
 " "$WORKFLOW"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## **User description**
Closes #343

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined dependency audit workflow execution settings.
  * Concurrency management is now handled by the shared workflow.
  * Existing triggers, permissions, and audit behavior remain unchanged.
  * Updated automated checks to verify the revised workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent dependency audits from canceling unrelated workflow runs

### What Changed
- Dependency audit runs are now grouped by workflow and branch or pull request
- New commits still cancel older audits for the same workflow and reference
- Audits from different workflows no longer cancel each other accidentally

### Impact
`✅ Fewer cross-workflow audit cancellations`
`✅ Reliable dependency checks on pull requests`
`✅ Lower redundant CI usage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
