### PR TITLE
chore: sync 1 org-standard workflow stub(s) from petry-projects/.github

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -7,8 +7,8 @@
 #   • This file is a THIN CALLER STUB. All noise-gate / reconcile logic lives
 #     in the reusable workflow above.
 #   • You MAY change: nothing in normal use. The `uses:` ref and `agent_ref`
-#     are pinned to the `add-to-project/stable` channel and move with it — do
-#     not change them to `@main` or a SHA (see ci-standards.md → Reusable
+#     are pinned to the `add-to-project/v1-stable` channel and move with it —
+#     do not change them to `@main` or a SHA (see ci-standards.md → Reusable
 #     workflow versioning).
 #   • You MUST NOT change: trigger events, the concurrency group, or the
 #     job-level `permissions:` block — a reusable can be granted no more
@@ -47,11 +47,11 @@ jobs:
   add-to-project:
     permissions:
       contents: read
-    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       project_id: PVT_kwDOD2inqs4BZq3-
       project_url: https://github.com/orgs/petry-projects/projects/1
-      agent_ref: add-to-project/stable
+      agent_ref: add-to-project/v1-stable
     # Pass only the secrets the reusable declares (least privilege; avoids
     # `secrets: inherit` handing the reusable every org secret).
     secrets:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -7,8 +7,8 @@
 #   • This file is a THIN CALLER STUB. All noise-gate / reconcile logic lives
 #     in the reusable workflow above.
 #   • You MAY change: nothing in normal use. The `uses:` ref and `agent_ref`
-#     are pinned to the `add-to-project/v1-stable` channel and move with it —
-#     do not change them to `@main` or a SHA (see ci-standards.md → Reusable
+#     are pinned to the `add-to-project/stable` channel and move with it — do
+#     not change them to `@main` or a SHA (see ci-standards.md → Reusable
 #     workflow versioning).
 #   • You MUST NOT change: trigger events, the concurrency group, or the
 #     job-level `permissions:` block — a reusable can be granted no more
@@ -47,11 +47,11 @@ jobs:
   add-to-project:
     permissions:
       contents: read
-    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       project_id: PVT_kwDOD2inqs4BZq3-
       project_url: https://github.com/orgs/petry-projects/projects/1
-      agent_ref: add-to-project/v1-stable
+      agent_ref: add-to-project/stable
     # Pass only the secrets the reusable declares (least privilege; avoids
     # `secrets: inherit` handing the reusable every org secret).
     secrets:


### PR DESCRIPTION
Syncs the following org-standard workflow stub(s) from `petry-projects/.github` (`standards/workflows/`), deployed verbatim:

- `add-to-project.yml`

Opened by `scripts/deploy-standard-workflows.sh`. Stubs are thin callers; all behaviour lives in the reusables. See `standards/ci-standards.md`. Labeled `standards-sync` and left for the normal review/auto-merge pipeline — the deploy script never merges directly.