### PR TITLE
chore: sync 4 org-standard workflow stub(s) from petry-projects/.github

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -56,14 +56,14 @@ permissions: {}
 
 jobs:
   dev-lead:
-    # Pinned to the moving dev-lead/stable channel tag, not @main, so a broken
+    # Pinned to the moving dev-lead/v1-stable channel tag, not @main, so a broken
     # change to dev-lead can no longer gate its own fix (the self-host circular
-    # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
+    # dependency). Promotion is done by moving the dev-lead/v1-stable tag centrally; this
     # caller is never edited on release. agent_ref threads the same channel into
     # dev-lead's own scripts/prompts checkout. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#dev-lead-agent.
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
-      agent_ref: dev-lead/stable
+      agent_ref: dev-lead/v1-stable
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -56,14 +56,14 @@ permissions: {}
 
 jobs:
   dev-lead:
-    # Pinned to the moving dev-lead/v1-stable channel tag, not @main, so a broken
+    # Pinned to the moving dev-lead/stable channel tag, not @main, so a broken
     # change to dev-lead can no longer gate its own fix (the self-host circular
-    # dependency). Promotion is done by moving the dev-lead/v1-stable tag centrally; this
+    # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
     # caller is never edited on release. agent_ref threads the same channel into
     # dev-lead's own scripts/prompts checkout. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#dev-lead-agent.
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
-      agent_ref: dev-lead/v1-stable
+      agent_ref: dev-lead/stable
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -182,7 +182,7 @@ jobs:
       discussions: write
       id-token: write
       actions: read
-    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       # All values below come from `needs.prep.outputs.*` (resolved in the `prep`
       # job) — NOT the `inputs` context — so this reusable `with:` compiles on the

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -44,6 +44,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: pr-auto-review-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-auto-review:
     permissions:

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -6,17 +6,17 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All readiness-gate logic lives in the
 #     reusable workflow above.
-#   • You MAY change: the tag in the `uses:` line when upgrading the reusable
-#     workflow version (e.g. bump `@v2` → `@v3` when petry-projects/.github cuts
-#     a new release), and the workflow name(s) in `workflow_run.workflows` to
-#     match your repository's CI workflow name(s).
-#   • You MUST NOT change: trigger event types or the job-level `permissions:`
-#     block — reusable workflows can be granted no more permissions than the
-#     calling job, so removing the stanza breaks the reusable's gh API calls.
+#   • You MAY change: the workflow name(s) in `workflow_run.workflows` to match
+#     your repository's CI workflow name(s).
+#   • You MUST NOT change: the `@pr-auto-review/v1-stable` channel in the `uses:`
+#     line — this reusable is on the org-wide moving-channel model (rollout and
+#     rollback are a single central tag move; a frozen `@vN`/`@<sha>` pin is
+#     rejected by the compliance audit). Nor the trigger event types or the
+#     job-level `permissions:` block — reusable workflows can be granted no more
+#     permissions than the calling job, so removing the stanza breaks the
+#     reusable's gh API calls.
 #   • If you need different behaviour, open a PR against the reusable in the
-#     central repo.
-#   • When publishing a new version of this reusable, also update this template
-#     and open a fanout PR across all caller repos.
+#     central repo. The change will propagate everywhere on next run.
 # ─────────────────────────────────────────────────────────────────────────────
 #
 # PR Auto-Review — thin caller for the org-level reusable.
@@ -28,8 +28,9 @@ on:
   # workflow_run fires when a named GitHub Actions workflow completes.
   # check_suite does NOT trigger for GitHub Actions runs, so this is required
   # to catch CI turning green on a PR.
+  # TODO: replace "CI" with your repository's CI workflow name(s).
   workflow_run:
-    workflows: ["CI", "AgentShield", "Dependency audit", "SonarCloud Analysis"]
+    workflows: ["CI"]
     types: [completed]
   # check_suite covers third-party CI checks (e.g. SonarCloud, external apps).
   check_suite:
@@ -43,20 +44,15 @@ on:
 
 permissions: {}
 
-# Collapse superseded runs on the same ref. Rapid automated PR pushes (e.g. from
-# the dev-lead bot) would otherwise each spawn a readiness-check run; the older
-# ones get held pending approval (action_required) and inflate the Fleet Monitor
-# failure rate (#274). Mirrors the fix applied to sonarcloud.yml in #263.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   pr-auto-review:
     permissions:
       pull-requests: read
       checks: read
       actions: read
-    uses: petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml@pr-auto-review/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml@pr-auto-review/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets:
-      GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}
+      # Canonical-first fallback (.github-private#1326). The reusable resolves this
+      # secret BY NAME, so only the VALUE changes — the passed key stays named
+      # GH_PAT_WORKFLOWS.
+      GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_DON_PETRY || secrets.GH_PAT_WORKFLOWS }}

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -7,7 +7,7 @@
 #   • This file is a THIN CALLER STUB. All review-dispatch logic lives in the
 #     reusable workflow above.
 #   • You MUST NOT change: the `uses:` ref — it is pinned to the
-#     `pr-review-mention/v2-stable` channel, a moving tag advanced centrally.
+#     `pr-review-mention/stable` channel, a moving tag advanced centrally.
 #     Never repoint it to `@main`, a SHA, or a frozen `@vX` (see
 #     ci-standards.md → Reusable workflow versioning). Also do not change the
 #     trigger events or the job-level `permissions:` block — reusable workflows
@@ -37,11 +37,15 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: pr-review-mention-${{ github.event_name }}-${{ github.event.issue.number }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets:
       GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_DON_PETRY || secrets.GH_PAT_WORKFLOWS }}
       DON_PETRY_BOT_GH_PAT: ${{ secrets.DON_PETRY_BOT_GH_PAT }}

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -7,7 +7,7 @@
 #   • This file is a THIN CALLER STUB. All review-dispatch logic lives in the
 #     reusable workflow above.
 #   • You MUST NOT change: the `uses:` ref — it is pinned to the
-#     `pr-review-mention/stable` channel, a moving tag advanced centrally.
+#     `pr-review-mention/v2-stable` channel, a moving tag advanced centrally.
 #     Never repoint it to `@main`, a SHA, or a frozen `@vX` (see
 #     ci-standards.md → Reusable workflow versioning). Also do not change the
 #     trigger events or the job-level `permissions:` block — reusable workflows
@@ -20,7 +20,11 @@
 #
 # PR Review Mention — thin caller for the org-level reusable.
 # To adopt: copy this file to .github/workflows/pr-review-mention.yml in your repo.
-# Requires: GH_PAT_WORKFLOWS org secret (already present in petry-projects org).
+# Requires (org secrets, already present in petry-projects org):
+#   GH_PAT_DON_PETRY     canonical PAT for API calls and dispatching the review agent.
+#                        GH_PAT_WORKFLOWS is the deprecated transition alias, kept as the
+#                        `||` fallback until the persona rename lands fleet-wide.
+#   DON_PETRY_BOT_GH_PAT PAT owned by donpetry-bot, for posting acknowledgement comments.
 name: PR Review — Mention Trigger
 
 on:
@@ -33,26 +37,11 @@ on:
 
 permissions: {}
 
-# Serialize runs on the same PR/issue conversation without cancelling in-progress
-# ones. A comment burst on one conversation (e.g. a batch of audit comments)
-# spawns many caller runs; with cancel-in-progress: true, superseding a *pending*
-# reusable-caller run — before the reusable resolves — makes GitHub record the
-# cancellation as a startup failure (0 jobs), which inflated the Fleet Monitor
-# failure rate (#333, superseding the #323 attempt). With cancel-in-progress:
-# false the superseded runs are recorded as clean `cancelled` instead. The group
-# keys on github.event_name (so distinct event types on the same conversation
-# don't cross-cancel) and the PR/issue number (so unrelated conversations don't
-# collapse — github.ref is the default branch for comment events). Mirrors the
-# fix applied to add-to-project.yml in #331.
-concurrency:
-  group: >-
-    pr-review-mention-${{ format('{0}-{1}', github.event_name,
-       github.event.issue.number || github.event.pull_request.number) }}
-  cancel-in-progress: false
-
 jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/stable  # NOSONAR(githubactions:S7637) first-party channel ref
-    secrets: inherit
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    secrets:
+      GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_DON_PETRY || secrets.GH_PAT_WORKFLOWS }}
+      DON_PETRY_BOT_GH_PAT: ${{ secrets.DON_PETRY_BOT_GH_PAT }}


### PR DESCRIPTION
Syncs the following org-standard workflow stub(s) from `petry-projects/.github` (`standards/workflows/`), deployed verbatim:

- `pr-review-mention.yml`
- `dev-lead.yml`
- `pr-auto-review.yml`
- `feature-ideation.yml`

Opened by `scripts/deploy-standard-workflows.sh`. Stubs are thin callers; all behaviour lives in the reusables. See `standards/ci-standards.md`. Labeled `standards-sync` and left for the normal review/auto-merge pipeline — the deploy script never merges directly.