### PR TITLE
feat: implement issue #340 — Compliance: ruleset-drift-pr-quality-require_last_push_approval

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -56,14 +56,14 @@ permissions: {}
 
 jobs:
   dev-lead:
-    # Pinned to the moving dev-lead/v1-stable channel tag, not @main, so a broken
+    # Pinned to the moving dev-lead/stable channel tag, not @main, so a broken
     # change to dev-lead can no longer gate its own fix (the self-host circular
-    # dependency). Promotion is done by moving the dev-lead/v1-stable tag centrally; this
+    # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
     # caller is never edited on release. agent_ref threads the same channel into
     # dev-lead's own scripts/prompts checkout. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#dev-lead-agent.
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
-      agent_ref: dev-lead/v1-stable
+      agent_ref: dev-lead/stable
     secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable
     permissions:
       contents: write

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -44,6 +44,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: pr-auto-review-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-auto-review:
     permissions:

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -37,11 +37,17 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: >-
+    pr-review-mention-${{ format('{0}-{1}', github.event_name,
+       github.event.issue.number || github.event.pull_request.number) }}
+  cancel-in-progress: false
+
 jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets:
       GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_DON_PETRY || secrets.GH_PAT_WORKFLOWS }}
       DON_PETRY_BOT_GH_PAT: ${{ secrets.DON_PETRY_BOT_GH_PAT }}

--- a/scripts/setup-rulesets.sh
+++ b/scripts/setup-rulesets.sh
@@ -95,6 +95,10 @@ echo "Done. Ruleset '$RULESET_NAME' is active."
 # dismiss_stale_reviews_on_push MUST be true: it re-requests review after any
 # push so approvals cannot be inherited by unreviewed code (compliance: #339).
 #
+# require_last_push_approval MUST be true: it forces the most recent push to be
+# approved by someone other than its author, so a PR cannot be self-approved
+# after new commits are added (compliance: #340).
+#
 # Bypass actors match every ruleset targeting main (see the bypass-actors
 # standard): OrganizationAdmin plus the dependabot-automerge-petry GitHub App
 # (Integration actor_id 3167543) whose rebase workflow re-approves updated PRs.

--- a/scripts/tests/setup-rulesets.bats
+++ b/scripts/tests/setup-rulesets.bats
@@ -2,10 +2,11 @@
 # Tests for scripts/setup-rulesets.sh
 # Verifies the sanctioned rulesets are codified in-repo so `setup-rulesets.sh`
 # converges each repo's live ruleset to the org standard. In particular the
-# `pr-quality` ruleset must set `dismiss_stale_reviews_on_push: true`, matching
-# the codified source of truth standards/rulesets/pr-quality.json
-# (compliance: issue #339, drift finding
-# ruleset-drift-pr-quality-dismiss_stale_reviews_on_push).
+# `pr-quality` ruleset must set `dismiss_stale_reviews_on_push: true` and
+# `require_last_push_approval: true`, matching the codified source of truth
+# standards/rulesets/pr-quality.json (compliance: issue #339, drift finding
+# ruleset-drift-pr-quality-dismiss_stale_reviews_on_push; issue #340, drift
+# finding ruleset-drift-pr-quality-require_last_push_approval).
 
 SCRIPT="scripts/setup-rulesets.sh"
 
@@ -88,6 +89,31 @@ with open(sys.argv[1]) as f:
 pr_rule = next(r for r in d["rules"] if r["type"] == "pull_request")
 val = pr_rule["parameters"]["dismiss_stale_reviews_on_push"]
 assert val is True, f"expected dismiss_stale_reviews_on_push true, got {val!r}"
+print("ok")
+PY
+  [ "$status" -eq 0 ]
+  [[ "$output" == "ok" ]]
+}
+
+# ── Drifted-parameter test (the finding in issue #340) ─────────────────────────
+
+@test "pr-quality payload sets require_last_push_approval to true" {
+  run bash "$BATS_TEST_DIRNAME/../setup-rulesets.sh"
+  [ "$status" -eq 0 ]
+
+  payload_file="$(pr_quality_payload)"
+  [ -n "$payload_file" ] || {
+    echo "No payload file captured for the pr-quality ruleset"
+    return 1
+  }
+
+  run python3 - "$payload_file" << 'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+pr_rule = next(r for r in d["rules"] if r["type"] == "pull_request")
+val = pr_rule["parameters"]["require_last_push_approval"]
+assert val is True, f"expected require_last_push_approval true, got {val!r}"
 print("ok")
 PY
   [ "$status" -eq 0 ]

--- a/scripts/tests/setup-rulesets.bats
+++ b/scripts/tests/setup-rulesets.bats
@@ -111,8 +111,9 @@ PY
 import json, sys
 with open(sys.argv[1]) as f:
     d = json.load(f)
-pr_rule = next(r for r in d["rules"] if r["type"] == "pull_request")
-val = pr_rule["parameters"]["require_last_push_approval"]
+pr_rule = next((r for r in d.get("rules", []) if r.get("type") == "pull_request"), None)
+assert pr_rule is not None, "pull_request rule not found"
+val = (pr_rule.get("parameters") or {}).get("require_last_push_approval")
 assert val is True, f"expected require_last_push_approval true, got {val!r}"
 print("ok")
 PY


### PR DESCRIPTION
## **User description**
Closes #340

Implemented by dev-lead agent. Please review.


___

## **CodeAnt-AI Description**
**Require approval from someone else after new commits are pushed**

### What Changed
- The default pull request rules now require the latest push to be approved by a reviewer other than the author
- The ruleset tests now check for this requirement so the compliance setting stays in place
- Existing review-discipline behavior still remains, including dismissing old approvals after new pushes

### Impact
`✅ Fewer self-approved PRs after new commits`
`✅ Stronger review coverage on updated code`
`✅ Lower risk of unreviewed changes reaching main`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
