### PR TITLE
feat: implement issue #418 — Compliance: ruleset-drift-pr-quality-dismiss_stale_reviews_on_push

### DIFF
--- a/scripts/setup-rulesets.sh
+++ b/scripts/setup-rulesets.sh
@@ -93,7 +93,8 @@ echo "Done. Ruleset '$RULESET_NAME' is active."
 #   standards/github-settings.md#pr-quality--standard-ruleset-all-repositories
 #
 # dismiss_stale_reviews_on_push MUST be true: it re-requests review after any
-# push so approvals cannot be inherited by unreviewed code (compliance: #339).
+# push so approvals cannot be inherited by unreviewed code (compliance: #339,
+# re-detected #388, #418).
 #
 # require_last_push_approval MUST be true: it forces the most recent push to be
 # approved by someone other than its author, so a PR cannot be self-approved

--- a/scripts/tests/setup-rulesets.bats
+++ b/scripts/tests/setup-rulesets.bats
@@ -4,7 +4,7 @@
 # converges each repo's live ruleset to the org standard. In particular the
 # `pr-quality` ruleset must set `dismiss_stale_reviews_on_push: true` and
 # `require_last_push_approval: true`, matching the codified source of truth
-# petry-projects/.github:standards/rulesets/pr-quality.json (compliance: issues #339 and #388, drift
+# petry-projects/.github:standards/rulesets/pr-quality.json (compliance: issues #339, #388, and #418, drift
 # finding ruleset-drift-pr-quality-dismiss_stale_reviews_on_push; issues #340
 # and #400, drift finding ruleset-drift-pr-quality-require_last_push_approval).
 #
@@ -177,6 +177,63 @@ pr_rule = next((r for r in d.get("rules", []) if r.get("type") == "pull_request"
 assert pr_rule is not None, "pull_request rule not found"
 val = (pr_rule.get("parameters") or {}).get("require_last_push_approval")
 assert val is True, f"expected require_last_push_approval true, got {val!r}"
+print("ok")
+PY
+  [ "$status" -eq 0 ]
+  [[ "$output" == "ok" ]]
+}
+
+# ── Existing-ruleset update path (PUT) — dismiss_stale_reviews_on_push ─────────
+# Converging a live repo takes the update (PUT) branch. This guards against a
+# regression that drops dismiss_stale_reviews_on_push when converging an
+# already-present ruleset (compliance: issue #339, re-detected #388 and #418).
+
+@test "pr-quality PUT payload sets dismiss_stale_reviews_on_push to true when ruleset exists" {
+  # Override the mock so the ruleset-existence lookup returns an id, forcing the
+  # update (PUT) branch instead of create (POST).
+  cat > "$MOCK_BIN/gh" << 'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "$CALLS_FILE"
+
+if [[ " $* " == *" --input - "* ]]; then
+  payload_file="$(mktemp "$PAYLOAD_DIR/payload.XXXXXX")"
+  cat > "$payload_file"
+  echo '{}'
+elif [[ "$*" == *--jq* ]]; then
+  # Ruleset lookup — return a non-empty id so the script updates (PUT) the
+  # existing ruleset instead of creating it.
+  printf '424242'
+else
+  echo '{}'
+fi
+MOCK
+  chmod +x "$MOCK_BIN/gh"
+
+  run bash "$BATS_TEST_DIRNAME/../setup-rulesets.sh"
+  [ "$status" -eq 0 ]
+
+  # The existing ruleset must be converged via PUT against its id, not POST.
+  grep -q "rulesets/424242 -X PUT" "$CALLS_FILE" || {
+    echo "Expected a PUT to the existing ruleset id; calls were:"
+    cat "$CALLS_FILE"
+    return 1
+  }
+
+  payload_file="$(pr_quality_payload)"
+  [ -n "$payload_file" ] || {
+    echo "No payload file captured for the pr-quality ruleset"
+    return 1
+  }
+
+  run python3 - "$payload_file" << 'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+pr_rule = next((r for r in d.get("rules", []) if r.get("type") == "pull_request"), None)
+assert pr_rule is not None, "pull_request rule not found"
+val = (pr_rule.get("parameters") or {}).get("dismiss_stale_reviews_on_push")
+assert val is True, f"expected dismiss_stale_reviews_on_push true, got {val!r}"
 print("ok")
 PY
   [ "$status" -eq 0 ]

--- a/scripts/tests/setup-rulesets.bats
+++ b/scripts/tests/setup-rulesets.bats
@@ -189,8 +189,13 @@ PY
 # already-present ruleset (compliance: issue #339, re-detected #388 and #418).
 
 @test "pr-quality PUT payload sets dismiss_stale_reviews_on_push to true when ruleset exists" {
-  # Override the mock so the ruleset-existence lookup returns an id, forcing the
-  # update (PUT) branch instead of create (POST).
+  # Override the mock so ONLY the pr-quality existence lookup returns an id,
+  # forcing pr-quality down the update (PUT) branch while code-quality stays on
+  # create (POST). Keeping the two rulesets on different paths means a regression
+  # that PUTs code-quality but POSTs pr-quality can no longer pass. Each captured
+  # payload gets a sidecar recording the exact request args that carried it, so
+  # the assertion can tie the pr-quality payload to its own PUT — not merely to
+  # "some" PUT that a different ruleset might have made.
   cat > "$MOCK_BIN/gh" << 'MOCK'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -199,11 +204,19 @@ echo "$*" >> "$CALLS_FILE"
 if [[ " $* " == *" --input - "* ]]; then
   payload_file="$(mktemp "$PAYLOAD_DIR/payload.XXXXXX")"
   cat > "$payload_file"
+  # Record the request args (method + target) that carried this payload so the
+  # test can associate a payload with the exact API call that sent it.
+  printf '%s' "$*" > "$payload_file.args"
   echo '{}'
 elif [[ "$*" == *--jq* ]]; then
-  # Ruleset lookup — return a non-empty id so the script updates (PUT) the
-  # existing ruleset instead of creating it.
-  printf '424242'
+  # Ruleset-existence lookup. Return a non-empty id ONLY for pr-quality so it
+  # takes the update (PUT) branch; code-quality gets an empty result and takes
+  # the create (POST) branch.
+  if [[ "$*" == *pr-quality* ]]; then
+    printf '424242'
+  else
+    printf ''
+  fi
 else
   echo '{}'
 fi
@@ -213,16 +226,18 @@ MOCK
   run bash "$BATS_TEST_DIRNAME/../setup-rulesets.sh"
   [ "$status" -eq 0 ]
 
-  # The existing ruleset must be converged via PUT against its id, not POST.
-  grep -q "rulesets/424242 -X PUT" "$CALLS_FILE" || {
-    echo "Expected a PUT to the existing ruleset id; calls were:"
-    cat "$CALLS_FILE"
-    return 1
-  }
-
   payload_file="$(pr_quality_payload)"
   [ -n "$payload_file" ] || {
     echo "No payload file captured for the pr-quality ruleset"
+    return 1
+  }
+
+  # The pr-quality payload itself must have been converged via PUT against the
+  # existing ruleset id — tie the payload to its own request, not to "some" PUT
+  # a different ruleset (e.g. code-quality) may have made.
+  grep -q "rulesets/424242 -X PUT" "$payload_file.args" || {
+    echo "Expected the pr-quality payload to be sent via PUT to the existing id; its request was:"
+    cat "$payload_file.args"
     return 1
   }
 


### PR DESCRIPTION
## **User description**
Closes #418

Implemented by dev-lead agent. Please review.


___

## **CodeAnt-AI Description**
Verify pull-request rules retain review protections when updated

### What Changed
- Added coverage for updating an existing `pr-quality` ruleset, ensuring it uses the update path and keeps stale-review dismissal enabled
- Expanded compliance references for the requirement that new pushes invalidate prior approvals

### Impact
`✅ Stale approvals invalidated after new pushes`
`✅ Existing rulesets retain required review protections`
`✅ Earlier compliance regressions are detected`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated compliance guidance to reflect additional stale-review dismissal detections.

* **Tests**
  * Added coverage to verify that existing pull request quality rules retain stale-review dismissal when updated.
  * Expanded compliance validation for stale-review dismissal settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->